### PR TITLE
Some performance improvments when using a BUNCH of projects with pmd set...

### DIFF
--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesManagerImpl.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesManagerImpl.java
@@ -97,6 +97,7 @@ public class ProjectPropertiesManagerImpl implements IProjectPropertiesManager {
         try {
             IProjectProperties projectProperties = this.projectsProperties.get(project);
             if (projectProperties == null) {
+            	log.debug("Creating new poject properties for " + project.getName());
                 projectProperties = new PropertiesFactoryImpl().newProjectProperties(project, this);
                 final ProjectPropertiesTO to = readProjectProperties(project);
                 fillProjectProperties(projectProperties, to);
@@ -152,12 +153,13 @@ public class ProjectPropertiesManagerImpl implements IProjectPropertiesManager {
      *
      */
     private void loadRuleSetFromProject(IProjectProperties projectProperties) throws PropertiesException {
-        if (projectProperties.isRuleSetFileExist()) {
+        if (projectProperties.isRuleSetFileExist() && projectProperties.isNeedRebuild()) {
             log.debug("Loading ruleset from project ruleset file: " + projectProperties.getRuleSetFile());
             try {
                 final RuleSetFactory factory = new RuleSetFactory();
                 final File ruleSetFile = projectProperties.getResolvedRuleSetFile();
                 projectProperties.setProjectRuleSet(factory.createRuleSets(ruleSetFile.getPath()).getAllRuleSets()[0]);
+                projectProperties.setNeedRebuild(false);
             } catch (RuleSetNotFoundException e) {
                 PMDPlugin.getDefault().logError(
                         "Project RuleSet cannot be loaded for project " + projectProperties.getProject().getName()


### PR DESCRIPTION
Some performance improvments when using a BUNCH of projects with pmd settings.

Notably:
1) If using project .ruleset, don't reload it for EVERY SINGLE FILE
2) Don't grab the "Workspace.run" lock if we aren't going to do anything
3) Limit the number of threads doing PMD work to 10.

Of Note:  loading Apache CXF into eclipse (50+ projects) and hitting "clean everything" would take over 1/2 an hour previously, now down to a couple minutes.  