### PR TITLE
More PMD plugin performance updates....

### DIFF
--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/FileChangeReviewer.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/FileChangeReviewer.java
@@ -7,6 +7,7 @@ import name.herlin.command.CommandException;
 import net.sourceforge.pmd.eclipse.runtime.builder.MarkerUtil;
 import net.sourceforge.pmd.eclipse.runtime.cmd.ReviewCodeCmd;
 
+import org.apache.log4j.Logger;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
@@ -110,6 +111,7 @@ public class FileChangeReviewer implements IResourceChangeListener {
 					if (monitor.isCanceled()) return;
 					changed(itemsChanged, grandkidDelta, monitor);
 				}
+				break;
 			case IResourceDelta.ADDED :
 //				if (rsc instanceof IProject) {
 //					removed(itemsChanged, (IProject)rsc, delta.getFlags());
@@ -121,6 +123,7 @@ public class FileChangeReviewer implements IResourceChangeListener {
 					if (monitor.isCanceled()) return;
 					changed(itemsChanged, grandkidDelta, monitor);
 				}		
+				break;
 			case IResourceDelta.CHANGED :
 //				if (rsc instanceof IProject) {
 //					changed(itemsChanged, (IProject)rsc, delta.getFlags());
@@ -131,7 +134,8 @@ public class FileChangeReviewer implements IResourceChangeListener {
 				for (IResourceDelta grandkidDelta : delta.getAffectedChildren()) {
 					if (monitor.isCanceled()) return;
 					changed(itemsChanged, grandkidDelta, monitor);
-				}			
+				}
+				break;
 			default :
 				for (IResourceDelta grandkidDelta : delta.getAffectedChildren()) {
 					if (monitor.isCanceled()) return;

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/ReviewCodeCmd.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/ReviewCodeCmd.java
@@ -102,6 +102,8 @@ public class ReviewCodeCmd extends AbstractDefaultCommand {
     private int 						fileCount;
     private long 						pmdDuration;
     private String						onErrorIssue = null;
+    
+    private IProjectProperties          propertyCache = null;
 
     private static final long serialVersionUID = 1L;
 
@@ -353,11 +355,17 @@ public class ReviewCodeCmd extends AbstractDefaultCommand {
             }
         }
     }
+    
+    private IProjectProperties getProjectProperties(IProject project) throws PropertiesException, CommandException {
+    	if (propertyCache == null || !propertyCache.getProject().getName().equals(project.getName())) {
+    		propertyCache = PMDPlugin.getDefault().loadProjectProperties(project);
+    	}
+		return propertyCache;
+    }
 
     private RuleSet rulesetFrom(IResource resource) throws PropertiesException, CommandException {
-    	
     	 IProject project = resource.getProject();
-         IProjectProperties properties = PMDPlugin.getDefault().loadProjectProperties(project);
+         IProjectProperties properties = getProjectProperties(project);
          
          return filteredRuleSet(properties);	//properties.getProjectRuleSet();
     }
@@ -369,7 +377,10 @@ public class ReviewCodeCmd extends AbstractDefaultCommand {
         try {
         	
             final IProject project = resource.getProject();
-            final IProjectProperties properties = PMDPlugin.getDefault().loadProjectProperties(project);
+            final IProjectProperties properties = getProjectProperties(project);
+            if (!properties.isPmdEnabled()) {
+            	return;
+            }
             
             final RuleSet ruleSet = rulesetFrom(resource);	//properties.getProjectRuleSet();
             
@@ -490,7 +501,7 @@ public class ReviewCodeCmd extends AbstractDefaultCommand {
     	
     	 IResource resource = resourceDelta.getResource();
          final IProject project = resource.getProject();
-         final IProjectProperties properties = PMDPlugin.getDefault().loadProjectProperties(project);
+         final IProjectProperties properties = getProjectProperties(project);
          
          return filteredRuleSet(properties);	//properties.getProjectRuleSet();
     }
@@ -502,7 +513,7 @@ public class ReviewCodeCmd extends AbstractDefaultCommand {
         try {
             IResource resource = resourceDelta.getResource();
             final IProject project = resource.getProject();
-            final IProjectProperties properties = PMDPlugin.getDefault().loadProjectProperties(project);
+            final IProjectProperties properties = getProjectProperties(project);
             
             RuleSet ruleSet = rulesetFromResourceDelta();	//properties.getProjectRuleSet();
 
@@ -655,4 +666,4 @@ public class ReviewCodeCmd extends AbstractDefaultCommand {
         }
     }
 
-}
+} 


### PR DESCRIPTION
Two major changes:
1) Bug in FileChangeReviewer was causing every resource in every change to be evaluated several times.  This even effects projects with PMD turned off.  A "clean" would take a lot longer than necessary.

2) In ReviewCodeCmd, save the last used IProjectProperties to avoid looking it up and checking for updates and such on every single file.   In most cases, every file in the set would have the same IProjectProperties so no reason to regrab for every file.

