### PR TITLE
Get to work "Check Code after saving" again

### DIFF
--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/FileChangeReviewer.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/FileChangeReviewer.java
@@ -13,8 +13,6 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IResourceChangeEvent;
 import org.eclipse.core.resources.IResourceChangeListener;
 import org.eclipse.core.resources.IResourceDelta;
-import org.eclipse.core.resources.IWorkspaceDescription;
-import org.eclipse.core.resources.ResourcesPlugin;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.core.runtime.IStatus;
@@ -67,12 +65,6 @@ public class FileChangeReviewer implements IResourceChangeListener {
      * @param event
      */
     public void resourceChanged(IResourceChangeEvent event) {
-        IWorkspaceDescription workspaceSettings = ResourcesPlugin.getWorkspace().getDescription();
-        if (workspaceSettings.isAutoBuilding()) {
-            PMDPlugin.getDefault().logInformation("Not running PMD, as autoBuilding is enabled for this workspace");
-            return;
-        }
-
         Set<ResourceChange> itemsChanged = new HashSet<ResourceChange>();
 
         switch (event.getType()) {


### PR DESCRIPTION
The "Check Code after saving" feature does not work if the option "Full Build enabled" is disabled. So you cannot let PMD check classes you modified without having PMD also check all classes on a full build.
This PR fixes that.
See https://github.com/pmd/pmd-eclipse-plugin/issues/10