### PR TITLE
squid:S1213 - The members of an interface declaration or class should…

### DIFF
--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/PMDPlugin.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/PMDPlugin.java
@@ -97,6 +97,17 @@ public class PMDPlugin extends AbstractUIPlugin {
     private static final Integer[] priorityValues = new Integer[] { Integer.valueOf(1), Integer.valueOf(2),
             Integer.valueOf(3), Integer.valueOf(4), Integer.valueOf(5) };
 
+    private static final Logger log = Logger.getLogger(PMDPlugin.class);
+
+    private StringTable stringTable; // NOPMD by Herlin on 11/10/06 00:22
+
+    public static final String ROOT_LOG_ID = "net.sourceforge.pmd";
+    private static final String PMD_ECLIPSE_APPENDER_NAME = "PMDEclipseAppender";
+    private IPreferencesFactory preferencesFactory = new PreferencesFactoryImpl();
+    private IPropertiesFactory propertiesFactory = new PropertiesFactoryImpl();
+
+    private final IRuleSetManager ruleSetManager = new RuleSetManagerImpl(); // NOPMD:SingularField
+
     /**
      * The constructor
      */
@@ -274,10 +285,6 @@ public class PMDPlugin extends AbstractUIPlugin {
         return plugin;
     }
 
-    private static final Logger log = Logger.getLogger(PMDPlugin.class);
-
-    private StringTable stringTable; // NOPMD by Herlin on 11/10/06 00:22
-
     /**
      * Returns an image descriptor for the image file at the given plug-in
      * relative path.
@@ -379,11 +386,6 @@ public class PMDPlugin extends AbstractUIPlugin {
         return priorityValues;
     }
 
-    public static final String ROOT_LOG_ID = "net.sourceforge.pmd";
-    private static final String PMD_ECLIPSE_APPENDER_NAME = "PMDEclipseAppender";
-    private IPreferencesFactory preferencesFactory = new PreferencesFactoryImpl();
-    private IPropertiesFactory propertiesFactory = new PropertiesFactoryImpl();
-
     /**
      * Load the PMD plugin preferences
      */
@@ -481,8 +483,6 @@ public class PMDPlugin extends AbstractUIPlugin {
             logError("IO Exception when configuring logging.", e);
         }
     }
-
-    private final IRuleSetManager ruleSetManager = new RuleSetManagerImpl(); // NOPMD:SingularField
 
     /**
      * @return the ruleset manager instance

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/AbstractDefaultCommand.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/AbstractDefaultCommand.java
@@ -63,6 +63,11 @@ public abstract class AbstractDefaultCommand extends AbstractProcessableCommand 
     private int stepCount;
     private boolean userInitiated;
 
+    protected AbstractDefaultCommand(String theName, String theDescription) {
+        name = theName;
+        description = theDescription;
+    }
+
 //    private static final Logger log = Logger.getLogger(AbstractDefaultCommand.class);
     
     public static void logInfo(String message) {
@@ -72,12 +77,7 @@ public abstract class AbstractDefaultCommand extends AbstractProcessableCommand 
     public static void logError(String message, Throwable error) {
     	PMDPlugin.getDefault().logError(message, error);
     }
-    
-    protected AbstractDefaultCommand(String theName, String theDescription) {
-    	name = theName;
-    	description = theDescription;
-    }
-    
+
     /**
      * 
      * @param file

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
@@ -87,12 +87,7 @@ public class BaseVisitor {
     protected RuleSet hiddenRules;
 
     private PMDConfiguration configuration;
-    
-    
-    protected PMDConfiguration configuration() {
-    	if (configuration == null) configuration = new PMDConfiguration();
-    	return configuration;
-    }
+
     /**
      * The constructor is protected to avoid illegal instantiation
      *
@@ -101,6 +96,11 @@ public class BaseVisitor {
         super();
 
         hiddenRules = new RuleSet();
+    }
+
+    protected PMDConfiguration configuration() {
+        if (configuration == null) configuration = new PMDConfiguration();
+        return configuration;
     }
 
     /**

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/impl/PreferenceUIStore.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/impl/PreferenceUIStore.java
@@ -44,7 +44,11 @@ public class PreferenceUIStore {
 	private static final boolean defaultSortUp = false;
 		
 	public static final PreferenceUIStore instance = new PreferenceUIStore();
-	
+
+	private PreferenceUIStore() {
+		initialize();
+	}
+
 	private static String defaultHiddenColumnIds() {
 		 Set<String> colNames = new HashSet<String>(defaultHiddenColumns.length);
 		 for (RuleColumnDescriptor rcDesc : defaultHiddenColumns) {
@@ -53,10 +57,6 @@ public class PreferenceUIStore {
 		 return SWTUtil.asString(colNames, stringSeparator);
 	}
 	
-	private PreferenceUIStore() { 
-		initialize();
-	}
-		
 	private void initialize() {
 		
         IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/IndexedString.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/IndexedString.java
@@ -12,7 +12,9 @@ public class IndexedString implements Comparable<IndexedString>{
 
 	public final String string;
 	public final List<int[]> indexSpans;
-	
+
+	public static final IndexedString Empty = new IndexedString("");
+
 	public IndexedString(String theString) {
 		this(theString, Collections.EMPTY_LIST);
 	}
@@ -30,6 +32,5 @@ public class IndexedString implements Comparable<IndexedString>{
 				other.string.compareTo(string) : 
 				deltaLength;
 	}
-	
-	public static final IndexedString Empty = new IndexedString("");
+
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/PageBuilder.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/PageBuilder.java
@@ -52,26 +52,26 @@ public class PageBuilder {
 			return sr1.start - sr2.start;
 		}
 	};
-	
+
+	public PageBuilder(int textIndent, int headingColorIndex, FontBuilder codeFontBuilder) {
+		buffer = new StringBuilder(500);
+		indentDepth = textIndent;
+
+		Display display = Display.getCurrent();
+		headingColor = display.getSystemColor(headingColorIndex);
+		codeStyle = codeFontBuilder.style(display);
+
+		SyntaxData syntax = SyntaxManager.getSyntaxData("java");
+		codeStyleExtractor = new StyleExtractor(syntax);
+	}
+
 	public static StyleRange[] sort(List<StyleRange> ranges) {
-		
+
 		StyleRange[] styles = ranges.toArray(new StyleRange[ranges.size()]);
 		Arrays.sort(styles, StyleComparator);
 		return styles;
 	}
-	
-	public PageBuilder(int textIndent, int headingColorIndex, FontBuilder codeFontBuilder) {
-		buffer = new StringBuilder(500);
-		indentDepth = textIndent;
-		
-		Display display = Display.getCurrent();		
-		headingColor = display.getSystemColor(headingColorIndex);
-		codeStyle = codeFontBuilder.style(display);
-		
-		SyntaxData syntax = SyntaxManager.getSyntaxData("java");
-		codeStyleExtractor = new StyleExtractor(syntax);
-	}
-	
+
 	public void indentDepth(int aDepth) { indentDepth = aDepth; }
 	public int indentDepth() { return indentDepth; }
 	
@@ -178,7 +178,7 @@ public class PageBuilder {
 			}
 		
 		String crStr = Character.toString(CR);
-		StyleRange sr;
+		StyleRange sr'';
 		
 		for (int i=0; i<codeSpans.size(); i++) {
 			span = codeSpans.get(i);

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/ShapePainter.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/ShapePainter.java
@@ -19,10 +19,10 @@ import org.eclipse.swt.widgets.Display;
  */
 public class ShapePainter {
 
-	private ShapePainter() {}
-
 	/** Provides a simple cache for the images. */
 	private static Map<String, Image> shapes = new HashMap<String, Image>();
+
+	private ShapePainter() {}
 
 	/**
 	 * Creates an image initialized with the transparent colour with the shape drawn within.

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/dialogs/NewPropertyDialog.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/dialogs/NewPropertyDialog.java
@@ -62,17 +62,6 @@ public class NewPropertyDialog extends TitleAreaDialog implements SizeChangeList
     private static final Class<?>[] validEditorTypes = new Class[] { String.class, Integer.class, Boolean.class, Class.class, Method.class };
     private static final Class<?> defaultEditorType = validEditorTypes[0];     // first one
 
-    public static Map<Class<?>, EditorFactory> withOnly(Map<Class<?>, EditorFactory> factoriesByType, Class<?>[] legalTypeKeys) {
-        Map<Class<?>, EditorFactory> results = new HashMap<Class<?>, EditorFactory>(legalTypeKeys.length);
-
-        for (Class<?> type : legalTypeKeys) {
-            if (factoriesByType.containsKey(type)) {
-                results.put(type, factoriesByType.get(type));
-            }
-        }
-        return results;
-    }
-
     /**
      * Constructor for RuleDialog.  Supply a working descriptor with name & description values we expect the user to change.
      *
@@ -97,6 +86,17 @@ public class NewPropertyDialog extends TitleAreaDialog implements SizeChangeList
         this(parent, theEditorFactoriesByValueType, theRule, theChangeListener);
 
         descriptor = theDescriptor;
+    }
+
+    public static Map<Class<?>, EditorFactory> withOnly(Map<Class<?>, EditorFactory> factoriesByType, Class<?>[] legalTypeKeys) {
+        Map<Class<?>, EditorFactory> results = new HashMap<Class<?>, EditorFactory>(legalTypeKeys.length);
+
+        for (Class<?> type : legalTypeKeys) {
+            if (factoriesByType.containsKey(type)) {
+                results.put(type, factoriesByType.get(type));
+            }
+        }
+        return results;
     }
 
     public boolean close() {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/filters/FilterHolder.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/filters/FilterHolder.java
@@ -16,7 +16,27 @@ class FilterHolder {
 	public boolean	isInclude;
 	
 	public static final FilterHolder[] EMPTY_HOLDERS = new FilterHolder[0];
-	
+
+	public static final Accessor ExcludeAccessor = new BasicAccessor() {
+		public boolean boolValueFor(FilterHolder fh) { return !fh.isInclude; }
+	};
+
+	public static final Accessor IncludeAccessor = new BasicAccessor() {
+		public boolean boolValueFor(FilterHolder fh) { return fh.isInclude; }
+	};
+
+	public static final Accessor PMDAccessor = new BasicAccessor() {
+		public boolean boolValueFor(FilterHolder fh) { return fh.forPMD; }
+	};
+
+	public static final Accessor CPDAccessor = new BasicAccessor() {
+		public boolean boolValueFor(FilterHolder fh) { return fh.forCPD; }
+	};
+
+	public static final Accessor PatternAccessor = new BasicAccessor() {
+		public String textValueFor(FilterHolder fh) { return fh.pattern; }
+	};
+
 	public FilterHolder(String thePattern, boolean pmdFlag, boolean cpdFlag, boolean isIncludeFlag) {
 		pattern = thePattern;
 		forPMD = pmdFlag;
@@ -28,27 +48,7 @@ class FilterHolder {
 		boolean boolValueFor(FilterHolder fh);
 		String textValueFor(FilterHolder fh);
 	}
-	
-	public static final Accessor ExcludeAccessor = new BasicAccessor() {
-		public boolean boolValueFor(FilterHolder fh) { return !fh.isInclude; }
-	};
-	
-	public static final Accessor IncludeAccessor = new BasicAccessor() {
-		public boolean boolValueFor(FilterHolder fh) { return fh.isInclude; }
-	};
-	
-	public static final Accessor PMDAccessor = new BasicAccessor() {
-		public boolean boolValueFor(FilterHolder fh) { return fh.forPMD; }
-	};
-	
-	public static final Accessor CPDAccessor = new BasicAccessor() {
-		public boolean boolValueFor(FilterHolder fh) { return fh.forCPD; }
-	};
-	
-	public static final Accessor PatternAccessor = new BasicAccessor() {
-		public String textValueFor(FilterHolder fh) { return fh.pattern; }
-	};
-	
+
 	public static Boolean boolValueOf(Collection<FilterHolder> holders, Accessor boolAccessor) {
 		Set<Boolean> values = new HashSet<Boolean>();
 		for (FilterHolder fh : holders) values.add(boolAccessor.boolValueFor(fh));

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/RuleSetSelectionDialog.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/RuleSetSelectionDialog.java
@@ -69,14 +69,7 @@ public class RuleSetSelectionDialog extends Dialog {
     private final RuleSet[] ruleSets;
     private final String[] ruleSetNames;
     private final RuleColumnDescriptor[] columns;
-    
-    private static String labelFor(RuleSet rs) {
-    	
-    	Collection<Rule> rules = rs.getRules();
-    	String lang = rules.iterator().next().getLanguage().getShortName();
-    	return lang + " - " + rs.getName() + "  (" + rules.size() + ")";
-    }
-    
+
     /**
      * Constructor for RuleSetSelectionDialog.
      * @param parentdlgArea
@@ -110,6 +103,13 @@ public class RuleSetSelectionDialog extends Dialog {
             }
             index++;
         }
+    }
+
+    private static String labelFor(RuleSet rs) {
+
+        Collection<Rule> rules = rs.getRules();
+        String lang = rules.iterator().next().getLanguage().getShortName();
+        return lang + " - " + rs.getName() + "  (" + rules.size() + ")";
     }
 
     protected void configureShell(Shell shell) {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/AbstractTableManager.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/AbstractTableManager.java
@@ -43,7 +43,17 @@ public abstract class AbstractTableManager<T extends Object> implements SortList
 	private final Set<ColumnDescriptor>	hiddenColumns = new HashSet<ColumnDescriptor>();
 
 	protected static PMDPlugin plugin = PMDPlugin.getDefault();
-	
+
+	public AbstractTableManager(String theWidgetId, IPreferences thePreferences, ColumnDescriptor[] theColumns) {
+		super();
+
+		widgetId = theWidgetId;
+		preferences = thePreferences;
+		availableColumns = theColumns;
+
+		loadHiddenColumns();
+	}
+
 	   protected static class WidthChangeThread extends Thread {
 	        private final int startWidth;
 	        private final int endWidth;
@@ -103,17 +113,7 @@ public abstract class AbstractTableManager<T extends Object> implements SortList
  			public Object getData(String key) { return column.getData(key); }
 		};
 	}
-	
-	public AbstractTableManager(String theWidgetId, IPreferences thePreferences, ColumnDescriptor[] theColumns) {
-		super();
 
-		widgetId = theWidgetId;
-		preferences = thePreferences;
-		availableColumns = theColumns;
-		
-		loadHiddenColumns();
-	}
-	
 	protected abstract ColumnWidthAdapter columnAdapterFor(ColumnDescriptor desc);
 	
 	protected void setupMenusFor(final Control control) {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/AbstractTreeTableManager.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/AbstractTreeTableManager.java
@@ -61,6 +61,10 @@ public abstract class AbstractTreeTableManager <T extends Object> extends Abstra
 		
 	private Map<Integer, List<Listener>> paintListeners = new HashMap<Integer, List<Listener>>();
 
+	public AbstractTreeTableManager(String theWidgetId, IPreferences thePreferences, ColumnDescriptor[] theColumns) {
+		super(theWidgetId, thePreferences, theColumns);
+	}
+
 	protected static ColumnWidthAdapter adapterFor(final TreeColumn column) {
 		return new ColumnWidthAdapter() {
 			public int width() { return column.getWidth();	}
@@ -70,11 +74,7 @@ public abstract class AbstractTreeTableManager <T extends Object> extends Abstra
  			public Object getData(String key) { return column.getData(key); }
 			};
 	}
-		
-	public AbstractTreeTableManager(String theWidgetId, IPreferences thePreferences, ColumnDescriptor[] theColumns) {
-		super(theWidgetId, thePreferences, theColumns);
-	}
-	
+
 	public Tree getControl() {
 		return treeViewer.getTree();
 	}

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/BasicTableManager.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/BasicTableManager.java
@@ -36,7 +36,13 @@ import org.eclipse.swt.widgets.TableItem;
 public class BasicTableManager <T extends Object> extends AbstractTableManager<T> {
 
 	protected TableViewer tableViewer;
-	
+
+	private static final int DefaultTableStyle = SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL | SWT.MULTI | SWT.FULL_SELECTION;
+
+	public BasicTableManager(String theWidgetId, IPreferences thePreferences, ColumnDescriptor[] theColumns) {
+		super(theWidgetId, thePreferences, theColumns);
+	}
+
 //	public interface Predicate0 {
 //		boolean value();
 //	}
@@ -54,12 +60,6 @@ public class BasicTableManager <T extends Object> extends AbstractTableManager<T
 			}
 		}
 		return -1;
-	}
-	
-	private static final int DefaultTableStyle = SWT.BORDER | SWT.H_SCROLL | SWT.V_SCROLL | SWT.MULTI | SWT.FULL_SELECTION;
-	
-	public BasicTableManager(String theWidgetId, IPreferences thePreferences, ColumnDescriptor[] theColumns) {
-		super(theWidgetId, thePreferences, theColumns);
 	}
 
 //	public void setStyle(int columnNo, Predicate0 predicate, TextStyle ifTrue, TextStyle ifFalse) {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/FormatManager.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/FormatManager.java
@@ -14,9 +14,9 @@ import net.sourceforge.pmd.lang.LanguageVersion;
  */
 public class FormatManager {
 
+    private static final Map<Class<?>, ValueFormatter> formattersByType = new HashMap<Class<?>, ValueFormatter>();
+
 	private FormatManager() {}
-	
-	private static final Map<Class<?>, ValueFormatter> formattersByType = new HashMap<Class<?>, ValueFormatter>();
 
 	static {   // used to render property values in short form in main table
 	    formattersByType.put(String.class,      ValueFormatter.StringFormatter);

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/PMDPreferencePage2.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/PMDPreferencePage2.java
@@ -88,7 +88,11 @@ public class PMDPreferencePage2 extends AbstractPMDPreferencePage implements Rul
         { RuleTableColumns.filterViolationRegex,	StringKeys.PREF_RULESET_GROUPING_REGEX },
 		{ null, 								  	StringKeys.PREF_RULESET_GROUPING_NONE }
 		};
-	
+
+	public PMDPreferencePage2() {
+
+	}
+
 	public static RulePropertyManager[] buildPropertyManagersOn(TabFolder folder, ValueChangeListener listener) {
 		
 		return new RulePropertyManager[] {
@@ -102,11 +106,7 @@ public class PMDPreferencePage2 extends AbstractPMDPreferencePage implements Rul
 //			    buildExampleTab(folder,     6, SWTUtil.stringFor(StringKeys.PREF_RULESET_TAB_EXAMPLES), listener),
 			    };
 	}
-	
-	public PMDPreferencePage2() {
 
-	}
-	
 	protected String descriptionId() {
 		return StringKeys.PREF_RULESET_TITLE;
 	}

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/RuleFieldAccessor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/RuleFieldAccessor.java
@@ -31,18 +31,6 @@ public interface RuleFieldAccessor {
 	String[] ruleTypeDFlow	= new String[] { "D", "Dataflow" };
 	String[] ruleTypeTypeRes= new String[] { "T", "Type resolving" };
 
-	/**
-	 * @param rule Rule
-	 * @return Comparable
-	 */
-	Comparable<?> valueFor(Rule rule);
-
-	Comparable<?> valueFor(RuleCollection collection);
-	
-	Set<Comparable<?>> uniqueValuesFor(RuleCollection collection);
-	
-	String labelFor(Rule rule);
-		
 	RuleFieldAccessor since = new BasicRuleFieldAccessor() {
 		public Comparable<String> valueFor(Rule rule) {
 			return rule.getSince();
@@ -173,4 +161,17 @@ public interface RuleFieldAccessor {
 			return RuleUtil.modifiedPropertiesIn(rule).size();
 		}
 	};
+
+	/**
+	 * @param rule Rule
+	 * @return Comparable
+	 */
+	Comparable<?> valueFor(Rule rule);
+
+	Comparable<?> valueFor(RuleCollection collection);
+
+	Set<Comparable<?>> uniqueValuesFor(RuleCollection collection);
+
+	String labelFor(Rule rule);
+
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/RuleSelection.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/RuleSelection.java
@@ -35,12 +35,12 @@ public class RuleSelection implements RuleCollection {
     public RuleSelection(Rule soleRule) {
     	this(new Object[] {soleRule} );
     }
-    
-    public boolean isEmpty() { return ruleItems == null || ruleItems.length == 0; }
-    
+
     public RuleSelection(Object[] theRuleItems) {
         ruleItems = theRuleItems;
     }
+
+	public boolean isEmpty() { return ruleItems == null || ruleItems.length == 0; }
 
     public void soleRule(Rule theRule) {
     	ruleItems = new Object[] { theRule };

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/RuleSetFieldAccessor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/RuleSetFieldAccessor.java
@@ -13,14 +13,6 @@ import net.sourceforge.pmd.RuleSet;
  */
 public interface RuleSetFieldAccessor {
 
-	Comparable<?> valueFor(RuleSet ruleSet);
-
-//	Comparable<?> valueFor(RuleSetCollection collection);
-	
-//	Set<Comparable<?>> uniqueValuesFor(RuleSetCollection collection);
-	
-	String labelFor(RuleSet ruleSet);
-
 	RuleSetFieldAccessor name = new BasicRuleSetFieldAccessor() {
 		public Comparable<String> valueFor(RuleSet ruleSet) {
 			return ruleSet.getName();
@@ -56,4 +48,13 @@ public interface RuleSetFieldAccessor {
 			return ruleSet.getExcludePatterns().size();
 		}
 	};
+
+	Comparable<?> valueFor(RuleSet ruleSet);
+
+//	Comparable<?> valueFor(RuleSetCollection collection);
+
+//	Set<Comparable<?>> uniqueValuesFor(RuleSetCollection collection);
+
+	String labelFor(RuleSet ruleSet);
+
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/ValueFormatter.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/ValueFormatter.java
@@ -18,10 +18,6 @@ import net.sourceforge.pmd.util.ClassUtil;
  */
 public interface ValueFormatter {
 
-    String format(Object value);
-    
-    void format(Object value, StringBuilder target);
-        
     ValueFormatter StringFormatter = new BasicValueFormatter(null) {
         public void format(Object value, StringBuilder target) {
             target.append(value == null ? "" : value);
@@ -137,6 +133,11 @@ public interface ValueFormatter {
            return new Date((Long)value).toString();
         }
     };
-    
+
     ValueFormatter[] TimeFormatters = new ValueFormatter[] { DateFromLongFormatter };
+
+    String format(Object value);
+
+    void format(Object value, StringBuilder target);
+
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/SWTUtil.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/SWTUtil.java
@@ -21,11 +21,11 @@ import org.eclipse.swt.widgets.Listener;
  */
 public class SWTUtil {
 
-	private SWTUtil() {}
-
 	private static PMDPlugin plugin = PMDPlugin.getDefault();
 
 	private static final String TOOLTIP_SUFFIX = ".tooltip";
+
+	private SWTUtil() {}
 
     public static void logInfo(String message) {
     	plugin.logInformation(message);

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/panelmanagers/FormArranger.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/panelmanagers/FormArranger.java
@@ -50,7 +50,21 @@ public class FormArranger implements ValueChangeListener {
 	private Control[][]                         widgets;
 
     private Map<PropertyDescriptor<?>, Control[]> controlsByProperty;
-    
+
+	/**
+	 * Constructor for FormArranger.
+	 * @param theParent Composite
+	 * @param factories Map<Class,EditorFactory>
+	 */
+	public FormArranger(Composite theParent, Map<Class<?>, EditorFactory> factories, ValueChangeListener listener, SizeChangeListener sizeListener) {
+		parent = theParent;
+		editorFactoriesByValueType = factories;
+		changeListener = chain(listener, this);
+		sizeChangeListener = sizeListener;
+
+		controlsByProperty = new HashMap<PropertyDescriptor<?>, Control[]>();
+	}
+
     /**
      * Echo the change to the second listener after notifying the primary one
      * 
@@ -72,20 +86,6 @@ public class FormArranger implements ValueChangeListener {
 			}    		
     	};
     }
-    
-	/**
-	 * Constructor for FormArranger.
-	 * @param theParent Composite
-	 * @param factories Map<Class,EditorFactory>
-	 */
-	public FormArranger(Composite theParent, Map<Class<?>, EditorFactory> factories, ValueChangeListener listener, SizeChangeListener sizeListener) {
-		parent = theParent;
-		editorFactoriesByValueType = factories;
-		changeListener = chain(listener, this);
-		sizeChangeListener = sizeListener;
-
-        controlsByProperty = new HashMap<PropertyDescriptor<?>, Control[]>();
-	}
 
     protected void register(PropertyDescriptor<?> property, Control[] controls) {
     	controlsByProperty.put(property, controls);

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/panelmanagers/RulePanelManager.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/panelmanagers/RulePanelManager.java
@@ -77,6 +77,14 @@ public class RulePanelManager extends AbstractRulePanelManager {
     
     public static final String ID = "rule";
 
+	// TODO move to RuleSet class
+	public static final Comparator<RuleSet> byNameComparator = new Comparator<RuleSet>() {
+
+		public int compare(RuleSet rsA, RuleSet rsB) {
+			return rsA.getName().compareTo(rsB.getName());
+		};
+	};
+
 	public RulePanelManager(String theTitle, EditorUsageMode theMode, ValueChangeListener theListener, RuleTarget theRuleSource) {
 		this(ID, theTitle, theMode, theListener, theRuleSource);
 	}
@@ -390,14 +398,6 @@ public class RulePanelManager extends AbstractRulePanelManager {
 
          return nameField;
      }
-
-    // TODO move to RuleSet class
-    public static final Comparator<RuleSet> byNameComparator = new Comparator<RuleSet>() {
-
-    	public int compare(RuleSet rsA, RuleSet rsB) {
-    		return rsA.getName().compareTo(rsB.getName());
-    	};
-    };
 
      private Combo buildRuleSetNameField(Composite parent) {
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/priority/PriorityDescriptor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/priority/PriorityDescriptor.java
@@ -31,7 +31,24 @@ public class PriorityDescriptor implements Cloneable {
 	private static final RGB ProtoTransparentColour = new RGB(1,1,1);	// almost full black, unlikely to be used
 	
 	private static final char DELIMITER = '_';
-	
+
+	public PriorityDescriptor(RulePriority thePriority, String theLabelKey, String theFilterTextKey, String theIconId, Shape theShape, RGB theColor, int theSize) {
+		this(thePriority, theLabelKey, theFilterTextKey, theIconId, new ShapeDescriptor(theShape, theColor, theSize));
+	}
+
+	private PriorityDescriptor(RulePriority thePriority) {
+		priority = thePriority;
+	}
+
+	public PriorityDescriptor(RulePriority thePriority, String theLabelKey, String theFilterTextKey, String theIconId, ShapeDescriptor theShape) {
+		priority = thePriority;
+		label = AbstractPMDAction.getString(theLabelKey);
+		description = "--";		// TODO
+		filterText = AbstractPMDAction.getString(theFilterTextKey);
+		iconId = theIconId;
+		shape = theShape;
+	}
+
 	public static PriorityDescriptor from(String text) {
 		
 		String[] values = text.split(Character.toString(DELIMITER));
@@ -50,7 +67,7 @@ public class PriorityDescriptor implements Cloneable {
 				Integer.parseInt(values[6])
 				);
 	}
-	
+
 	private static Shape shapeFrom(String id) {
 		int num = Integer.parseInt(id);
 		for (Shape shape : EnumSet.allOf(Shape.class)) {
@@ -73,23 +90,6 @@ public class PriorityDescriptor implements Cloneable {
 		sb.append(rgb.red).append(',');
 		sb.append(rgb.green).append(',');
 		sb.append(rgb.blue);
-	}
-	
-	public PriorityDescriptor(RulePriority thePriority, String theLabelKey, String theFilterTextKey, String theIconId, ShapeDescriptor theShape) {
-		priority = thePriority;
-		label = AbstractPMDAction.getString(theLabelKey);
-		description = "--";		// TODO
-		filterText = AbstractPMDAction.getString(theFilterTextKey);
-		iconId = theIconId;
-		shape = theShape;
-	}
-	
-	public PriorityDescriptor(RulePriority thePriority, String theLabelKey, String theFilterTextKey, String theIconId, Shape theShape, RGB theColor, int theSize) {
-		this(thePriority, theLabelKey, theFilterTextKey, theIconId, new ShapeDescriptor(theShape, theColor, theSize));
-	}
-	
-	private PriorityDescriptor(RulePriority thePriority) {
-		priority = thePriority;
 	}
 
 	public String storeString() {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/AbstractPMDPagebookView.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/AbstractPMDPagebookView.java
@@ -26,7 +26,10 @@ import net.sourceforge.pmd.eclipse.ui.model.FileRecord;
 public abstract class AbstractPMDPagebookView extends PageBookView {
 
     protected ViewMemento memento;
-	
+
+    protected AbstractPMDPagebookView() {
+    }
+
     public static FileRecord tryForFileRecordFrom(IWorkbenchPart part) {
     	
     	if (part instanceof IEditorPart) {
@@ -39,9 +42,6 @@ public abstract class AbstractPMDPagebookView extends PageBookView {
     		}
        return null;
     }
-    
-	protected AbstractPMDPagebookView() {
-	}
 
     protected abstract String pageMessageId();
     

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/AbstractResourceView.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/AbstractResourceView.java
@@ -21,12 +21,12 @@ import org.eclipse.ui.IWorkbenchPart;
  */
 public abstract class AbstractResourceView extends AbstractPMDPagebookView implements IResourceChangeListener {
 
+    protected AbstractResourceView() {
+    }
+
 	protected static boolean getBoolUIPref(String prefId) { return pStore().getBoolean(prefId); }
 	
 	protected static IPreferenceStore pStore() { return PMDPlugin.getDefault().getPreferenceStore(); }
-	
-	protected AbstractResourceView() {
-	}
 
 	protected abstract AbstractStructureInspectorPage getCurrentViewPage();
 	

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/actions/DisableRuleAction.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/actions/DisableRuleAction.java
@@ -23,7 +23,11 @@ import org.eclipse.jface.viewers.TableViewer;
 public class DisableRuleAction extends AbstractViolationSelectionAction {
 
 	private final IPreferences preferences = PMDPlugin.getDefault().loadPreferences();
-    
+
+    public DisableRuleAction(TableViewer viewer) {
+        super(viewer);
+    }
+
     public static void disableRulesFor(Collection<Rule> rules, IPreferences preferences) {
     	
            for (Rule rule : rules) {
@@ -44,10 +48,6 @@ public class DisableRuleAction extends AbstractViolationSelectionAction {
          
          System.out.println("Violations deleted: " + deletions);
     }
-    
-	public DisableRuleAction(TableViewer viewer) {
-		super(viewer);
-	}
 
 	protected String textId() { return StringKeys.VIEW_ACTION_DISABLE_RULE; }
  	

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ast/ASTContentProvider.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ast/ASTContentProvider.java
@@ -31,10 +31,7 @@ public class ASTContentProvider implements ITreeContentProvider {
 			return a.getBeginLine() - b.getBeginLine();
 		}
 	};
-	
-	public void includeImports(boolean flag) { includeImports = flag; }
-	public void includeComments(boolean flag) { includeComments = flag; }
-	
+
 	public ASTContentProvider(boolean includeImportsFlag, boolean includeCommentsFlag) {
 		this(Collections.EMPTY_SET);
 		
@@ -45,6 +42,9 @@ public class ASTContentProvider implements ITreeContentProvider {
 	public ASTContentProvider(Set<Class<?>> theHiddenNodeTypes) {
 	//	hiddenNodeTypes = theHiddenNodeTypes;
 	}
+
+	public void includeImports(boolean flag) { includeImports = flag; }
+	public void includeComments(boolean flag) { includeComments = flag; }
 
 	public void dispose() {	}
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ast/ASTUtil.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ast/ASTUtil.java
@@ -25,14 +25,14 @@ import net.sourceforge.pmd.lang.java.ast.AbstractJavaAccessNode;
  */
 public class ASTUtil {
 
-	private ASTUtil() {}
-	
 	public static final Comparator<ASTMethodDeclaration> MethodComparator = new Comparator<ASTMethodDeclaration>() {
 		public int compare(ASTMethodDeclaration m1, ASTMethodDeclaration m2) {
 			return m1.getMethodName().compareTo(m2.getMethodName());
 		}
 	};
-	
+
+	private ASTUtil() {}
+
 	public static String getAnnotationLabel(ASTAnnotation annotation) {
 		
 		AbstractNode name = annotation.getFirstChildOfType(ASTName.class);

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ast/ASTView.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ast/ASTView.java
@@ -27,12 +27,12 @@ public class ASTView extends AbstractResourceView {
 	
 	private static final String ShowImports = "ASTView.showImports";
 	private static final String ShowComments = "ASTView.showComments";
-	
-	static boolean showImports() { return getBoolUIPref(ShowImports); }
-	static boolean showComments() { return getBoolUIPref(ShowComments); }
-	
+
 	public ASTView() {
 	}
+
+	static boolean showImports() { return getBoolUIPref(ShowImports); }
+	static boolean showComments() { return getBoolUIPref(ShowComments); }
 
     protected String pageMessageId() { return StringKeys.VIEW_AST_DEFAULT_TEXT; }
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ast/ASTViewPage.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ast/ASTViewPage.java
@@ -73,7 +73,16 @@ public class ASTViewPage extends AbstractStructureInspectorPage {
 		HiddenNodeTypes = new HashSet<Class<?>>();
 		HiddenNodeTypes.add(ASTImportDeclaration.class);
 	}
-	
+
+	/**
+	 *
+	 * @param part
+	 * @param record the FileRecord
+	 */
+	public ASTViewPage(IWorkbenchPart part, FileRecord record) {
+		super(part, record);
+	}
+
 	public TreeViewer astViewer() {
 		return astViewer;
 	}
@@ -87,16 +96,7 @@ public class ASTViewPage extends AbstractStructureInspectorPage {
 		contentProvider.includeComments(flag); 
 		astViewer.refresh(); 
 	}
-	
-	/**
-	 *
-	 * @param part
-	 * @param record the FileRecord
-	 */
-	public ASTViewPage(IWorkbenchPart part, FileRecord record) {
-		super(part, record);
-	}
-	
+
 	/**
 	 * TODO use an adjustable Sash to separate the two sections
 	 * TODO add an XPath version combo widget

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ast/CommentUtil.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ast/CommentUtil.java
@@ -11,10 +11,10 @@ import net.sourceforge.pmd.util.StringUtil;
 
 public class CommentUtil {
 
-	private CommentUtil() {}
-	
 	private static final String CR = "\n";
-	
+
+	private CommentUtil() {}
+
 	public static String wordAfter(String text, int position) {
 		
 		if (position >= text.length()) return null;

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ast/NodeImageDeriver.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ast/NodeImageDeriver.java
@@ -21,25 +21,7 @@ import net.sourceforge.pmd.lang.java.ast.Comment;
  * @author Brian Remedios
  */
 public class NodeImageDeriver {
-	
-	public final Class<?> target;
-	
-	public NodeImageDeriver(Class<?> theASTClass) {
-		target = theASTClass;
-	}
-	
-	public String deriveFrom(Node node) {
-		return null;	// failed to implement!
-	}
 
-	private static void dumpComments(ASTCompilationUnit node) {
-		
-		for (Comment comment : node.getComments()) {
-			System.out.println(comment.getClass().getName());
-			System.out.println(comment.getImage());
-		}
-	}
-	
 	private static NodeImageDeriver compilationUnitDeriver = new NodeImageDeriver(ASTCompilationUnit.class) {
 		public String deriveFrom(Node node) {
 			dumpComments((ASTCompilationUnit)node);
@@ -90,7 +72,25 @@ public class NodeImageDeriver {
 		};
 	
 	private static final Map<Class<?>, NodeImageDeriver>DeriversByType = new HashMap<Class<?>, NodeImageDeriver>(NodeImageDeriver.AllDerivers.length);
-	
+
+	public final Class<?> target;
+
+	public NodeImageDeriver(Class<?> theASTClass) {
+		target = theASTClass;
+	}
+
+	public String deriveFrom(Node node) {
+		return null;	// failed to implement!
+	}
+
+	private static void dumpComments(ASTCompilationUnit node) {
+
+		for (Comment comment : node.getComments()) {
+			System.out.println(comment.getClass().getName());
+			System.out.println(comment.getImage());
+		}
+	}
+
 	static {
 		for (NodeImageDeriver deriver : NodeImageDeriver.AllDerivers) {
 			DeriversByType.put(deriver.target, deriver);

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/util/ColourManager.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/util/ColourManager.java
@@ -23,15 +23,15 @@ public class ColourManager {
 	private final Map<RGB, Color> coloursByRGB = new HashMap<RGB, Color>();
 	
 	private static ColourManager instance;
-	
+
+	private ColourManager(Display theDisplay) {
+		display = theDisplay;
+	}
+
 	public static ColourManager managerFor(Display display) {
 	    
 	    if (instance == null) instance = new ColourManager(display);
 	    return instance;
-	}
-	
-	private ColourManager(Display theDisplay) {
-		display = theDisplay;
 	}
 
 	public Color colourFor(RGB colourFractions) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1213

Please let me know if you have any questions.

M-Ezzat