### PR TITLE
[core] Typesafe properties

### DIFF
--- a/net.sourceforge.pmd.eclipse.plugin/messages.properties
+++ b/net.sourceforge.pmd.eclipse.plugin/messages.properties
@@ -24,6 +24,7 @@ preference.pmd.group.priorities = Priority levels
 preference.pmd.group.review = Violations review parameters
 preference.pmd.group.general = General options
 preference.pmd.label.perspective_on_check = Show PMD perspective when checking code
+preference.pmd;label.check_after_saving = Check code after saving
 preference.pmd.label.use_dfa = Enable dataflow anomaly analysis (experimental)
 preference.pmd.label.use_project_build_path = Enable using Java Project Build Path.  Disable if your Eclipse JVM version is incompatible with .class file versions.
 preference.pmd.label.max_violations_pfpr = Maximum reported violations per file per rule

--- a/net.sourceforge.pmd.eclipse.plugin/nl/fr/messages.properties
+++ b/net.sourceforge.pmd.eclipse.plugin/nl/fr/messages.properties
@@ -21,6 +21,7 @@ preference.pmd.message.incorrect_format = Format de message incorrect
 preference.pmd.group.review = Paramètres de revue des violations
 preference.pmd.group.general = Options générales
 preference.pmd.label.perspective_on_check = Basculer sur la perspective PMD après la vérification (mode manuel seulement)
+preference.pmd.label.check_after_saving = Vérifier à chaque sauvegarde
 preference.pmd.label.use_dfa = Activer l'analyse d'anomalie de flots de données (expérimental)
 preference.pmd.label.use_project_build_path = Activer l'utilisation du chemin de construction du projet. A désactiver si la machine virtuelle de votre Eclipse est incompatible avec la version des fichiers .class.
 preference.pmd.label.max_violations_pfpr = Nombre maximal de violations reportées par fichier et par règle

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/PMDPlugin.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/PMDPlugin.java
@@ -231,7 +231,6 @@ public class PMDPlugin extends AbstractUIPlugin {
 
         // if a project is deleted, remove the cached project properties
         ResourcesPlugin.getWorkspace().addResourceChangeListener(new IResourceChangeListener() {
-            @Override
             public void resourceChanged(IResourceChangeEvent arg0) {
                 if (arg0.getType() == IResourceChangeEvent.PRE_DELETE && arg0.getResource() instanceof IProject) {
                     getPropertiesManager().removeProjectProperties((IProject) arg0.getResource());
@@ -239,7 +238,7 @@ public class PMDPlugin extends AbstractUIPlugin {
             }
         });
 
-        VERSION = context.getBundle().getHeaders().get("Bundle-Version");
+        VERSION = context.getBundle().getHeaders().get((Object) "Bundle-Version");
     }
 
     public void fileChangeListenerEnabled(boolean flag) {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/PMDPlugin.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/PMDPlugin.java
@@ -238,7 +238,7 @@ public class PMDPlugin extends AbstractUIPlugin {
             }
         });
 
-        VERSION = context.getBundle().getHeaders().get((Object) "Bundle-Version");
+        VERSION = context.getBundle().getHeaders().get("Bundle-Version");
     }
 
     public void fileChangeListenerEnabled(boolean flag) {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/nls/StringKeys.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/nls/StringKeys.java
@@ -66,6 +66,7 @@ public class StringKeys {
     public static final String PREF_GENERAL_GROUP_PRIORITIES = "preference.pmd.group.priorities";
     public static final String PREF_GENERAL_GROUP_GENERAL = "preference.pmd.group.general";
     public static final String PREF_GENERAL_LABEL_SHOW_PERSPECTIVE = "preference.pmd.label.perspective_on_check";
+    public static final String PREF_GENERAL_LABEL_CHECK_AFTER_SAVING = "preference.pmd.label.check_after_saving";
     public static final String PREF_GENERAL_LABEL_USE_DFA = "preference.pmd.label.use_dfa";
     public static final String PREF_GENERAL_LABEL_USE_PROJECT_BUILD_PATH = "preference.pmd.label.use_project_build_path";
     public static final String PREF_GENERAL_LABEL_MAX_VIOLATIONS_PFPR = "preference.pmd.label.max_violations_pfpr";

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/GeneralPreferencesPage.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/GeneralPreferencesPage.java
@@ -577,7 +577,7 @@ public class GeneralPreferencesPage extends PreferencePage implements IWorkbench
      */
     private Button buildCheckCodeOnSaveButton(Composite viewGroup) {
         Button button = new Button(viewGroup, SWT.CHECK);
-        button.setText("Check code after saving");
+        button.setText(StringKeys.PREF_GENERAL_LABEL_CHECK_AFTER_SAVING);
         button.setSelection(preferences.isCheckAfterSaveEnabled());
         return button;
     }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/EditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/EditorFactory.java
@@ -1,17 +1,16 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.br;
 
-import net.sourceforge.pmd.PropertyDescriptor;
-import net.sourceforge.pmd.PropertySource;
-import net.sourceforge.pmd.Rule;
-
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 
+import net.sourceforge.pmd.PropertyDescriptor;
+import net.sourceforge.pmd.PropertySource;
+
 /**
  * @author Brian Remedios
  */
-public interface EditorFactory {
+public interface EditorFactory<T> {
 
     /**
      * Have the factory create a descriptor using the name and description provided and use any
@@ -19,32 +18,38 @@ public interface EditorFactory {
      * earlier.
      *
      * @param name
-     * @param optionalDescription
      * @param otherData
-     * @return PropertyDescriptor<?>
+     *
+     * @return PropertyDescriptor<T>
      */
-    PropertyDescriptor<?> createDescriptor(String name, String description, Control[] otherData);
+    PropertyDescriptor<T> createDescriptor(String name, String description, Control[] otherData);
+
 
     /**
      * Instantiate and return a label for the descriptor on the parent provided.
      *
      * @param parent
      * @param desc
+     *
      * @return
      */
-    Label addLabel(Composite parent, PropertyDescriptor<?> desc);
+    Label addLabel(Composite parent, PropertyDescriptor<T> desc);
+
 
     /**
      * Creates a property value editor widget(s) on the parent for the specified descriptor
      * and rule. It does not perform any layout operations or set form attachments.
      *
-     * @param parent Composite
-     * @param desc PropertyDescriptor
-     * @param rule Rule
+     * @param parent   Composite
+     * @param desc     PropertyDescriptor
+     * @param rule     Rule
      * @param listener ValueChangeListener
+     *
      * @return Control
      */
-    Control newEditorOn(Composite parent, PropertyDescriptor<?> desc, PropertySource source, ValueChangeListener listener, SizeChangeListener sizeListener);
+    Control newEditorOn(Composite parent, PropertyDescriptor<T> desc, PropertySource source, ValueChangeListener
+        listener, SizeChangeListener sizeListener);
+
 
     /**
      * Create an array of label-widget pairs on the parent composite for the
@@ -57,7 +62,9 @@ public interface EditorFactory {
      * @param rule
      * @param listener
      * @param sizeListener
+     *
      * @return Control[]
      */
-    Control[] createOtherControlsOn(Composite parent, PropertyDescriptor<?> desc, PropertySource source, ValueChangeListener listener, SizeChangeListener sizeListener);
+    Control[] createOtherControlsOn(Composite parent, PropertyDescriptor<T> desc, PropertySource source,
+                                    ValueChangeListener listener, SizeChangeListener sizeListener);
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/AbstractEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/AbstractEditorFactory.java
@@ -1,29 +1,28 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
-import net.sourceforge.pmd.PropertyDescriptor;
-import net.sourceforge.pmd.PropertySource;
-import net.sourceforge.pmd.Rule;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.EditorFactory;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-import net.sourceforge.pmd.eclipse.util.ColourManager;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Label;
 
+import net.sourceforge.pmd.PropertyDescriptor;
+import net.sourceforge.pmd.PropertySource;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.EditorFactory;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
+import net.sourceforge.pmd.eclipse.util.ColourManager;
+
 /**
- *
  * @author Brian Remedios
  */
-public abstract class AbstractEditorFactory implements EditorFactory {
+public abstract class AbstractEditorFactory<T> implements EditorFactory<T> {
 
-    protected static ColourManager  colourManager;
+    protected static ColourManager colourManager;
 //    protected static Color          overriddenColour;
 
-	protected AbstractEditorFactory() { }
+
+    protected AbstractEditorFactory() { }
 
 //	private static ColourManager colourManager() {
 //
@@ -40,67 +39,66 @@ public abstract class AbstractEditorFactory implements EditorFactory {
 //	    return overriddenColour;
 //	}
 
-	protected Label newLabel(Composite parent, String text) {
-	    Label label = new Label(parent, SWT.None);
-	    label.setText(text);
-	    return label;
-	}
 
-	/**
-	 * Generic control that provides a label/widget pair for the default value. Subclasses can override this to provide additional
-	 * labels & widgets as necessary but must be able to extract the values held by them when the property is created.
-	 */
-	public Control[] createOtherControlsOn(Composite parent, PropertyDescriptor<?> desc, PropertySource source, ValueChangeListener listener, SizeChangeListener sizeListener) {
-	    return new Control[] {
-	        newLabel(parent,"Default"),
-	        newEditorOn(parent, desc, source, listener, sizeListener)
-	        };
-	}
-
-	protected abstract Object valueFrom(Control valueControl);
-
-    protected Object valueFor(PropertySource source, PropertyDescriptor<?> desc) {
-
-        return source.hasDescriptor(desc) ?
-        		source.getProperty(desc) :
-                desc.defaultValue();
+    /**
+     * Generic control that provides a label/widget pair for the default value. Subclasses can override this to provide
+     * additional labels & widgets as necessary but must be able to extract the values held by them when the property is
+     * created.
+     */
+    public Control[] createOtherControlsOn(Composite parent, PropertyDescriptor<T> desc, PropertySource source,
+                                           ValueChangeListener listener, SizeChangeListener sizeListener) {
+        return new Control[] {
+            newLabel(parent, "Default"),
+            newEditorOn(parent, desc, source, listener, sizeListener)
+        };
     }
 
-	/**
-	 * Method addLabel.
-	 * @param parent Composite
-	 * @param desc PropertyDescriptor
-	 * @return Label
-	 */
-	public Label addLabel(Composite parent, PropertyDescriptor<?> desc) {
 
-		Label label = new Label(parent, SWT.NONE);
-		label.setText(desc.description());
-		GridData data = new GridData();
-		data.horizontalAlignment = SWT.LEFT;
-		data.verticalAlignment = SWT.CENTER;  // CENTER is preferred only when showing a single row value widget...hmm
-		label.setLayoutData(data);
-		return label;
-	}
+    protected Label newLabel(Composite parent, String text) {
+        Label label = new Label(parent, SWT.None);
+        label.setText(text);
+        return label;
+    }
 
-	/**
-	 * Return the value as a string that can be easily recognized and parsed
-	 * when we see it again.
-	 *
-	 * @param value Object
-	 * @return String
-	 */
-	protected static String asString(Object value) {
-		return value == null ? "" : value.toString();
-	}
 
-	/**
-	 * Adjust the display of the control to denote whether it holds
-	 * onto the default value or not.
-	 *
-	 * @param control
-	 * @param hasDefaultValue
-	 */
+    protected abstract T valueFrom(Control valueControl);
+
+
+    protected T valueFor(PropertySource source, PropertyDescriptor<T> desc) {
+
+        return source.hasDescriptor(desc) ?
+               source.getProperty(desc) :
+               desc.defaultValue();
+    }
+
+
+    /**
+     * Method addLabel.
+     *
+     * @param parent Composite
+     * @param desc   PropertyDescriptor
+     *
+     * @return Label
+     */
+    public Label addLabel(Composite parent, PropertyDescriptor<T> desc) {
+
+        Label label = new Label(parent, SWT.NONE);
+        label.setText(desc.description());
+        GridData data = new GridData();
+        data.horizontalAlignment = SWT.LEFT;
+        data.verticalAlignment = SWT.CENTER;  // CENTER is preferred only when showing a single row value widget...hmm
+        label.setLayoutData(data);
+        return label;
+    }
+
+
+    /**
+     * Adjust the display of the control to denote whether it holds
+     * onto the default value or not.
+     *
+     * @param control
+     * @param hasDefaultValue
+     */
 //	protected void adjustRendering(Control control, boolean hasDefaultValue) {
 //
 //	    Display display = control.getDisplay();
@@ -109,11 +107,10 @@ public abstract class AbstractEditorFactory implements EditorFactory {
 //	       display.getSystemColor(hasDefaultValue ? SWT.COLOR_WHITE : SWT.COLOR_CYAN)
 //	       );
 //	}
+    protected void adjustRendering(PropertySource source, PropertyDescriptor<?> desc, Control control) {
 
-	protected void adjustRendering(PropertySource source, PropertyDescriptor<?> desc, Control control) {
+        return;    // don't do it...kinda irritating
 
-		return;	// don't do it...kinda irritating
-		
 //	        if (!(rule instanceof RuleReference)) return;
 //
 //	        boolean isOverridden = ((RuleReference)rule).hasOverriddenProperty(desc);
@@ -121,37 +118,19 @@ public abstract class AbstractEditorFactory implements EditorFactory {
 //	        Color clr = isOverridden ? overriddenColour() : display.getSystemColor(SWT.COLOR_WHITE);
 //
 //	        control.setBackground(clr);
-	}
+    }
 
-	/**
-	 * Return the specified values as a single string using the delimiter.
-	 * @param values Object
-	 * @param delimiter char
-	 * @return String
-	 * @see net.sourceforge.pmd.PropertyDescriptor#asDelimitedString(Object)
-	 */
-	public static String asDelimitedString(Object values, char delimiter) {
 
-		if (values == null) {
-		    return "";
-		}
+    /**
+     * Return the value as a string that can be easily recognized and parsed
+     * when we see it again.
+     *
+     * @param value Object
+     *
+     * @return String
+     */
+    protected static String asString(Object value) {
+        return value == null ? "" : value.toString();
+    }
 
-		if (values instanceof Object[]) {
-			Object[] valueSet = (Object[])values;
-			if (valueSet.length == 0) {
-			    return "";
-			}
-			if (valueSet.length == 1) {
-			    return asString(valueSet[0]);
-			}
-
-			StringBuilder sb = new StringBuilder(asString(valueSet[0]));
-			for (int i=1; i<valueSet.length; i++) {
-				sb.append(delimiter).append(asString(valueSet[i]));
-			}
-			return sb.toString();
-			}
-
-		return asString(values);
-	}
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/AbstractMultiValueEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/AbstractMultiValueEditorFactory.java
@@ -59,7 +59,7 @@ public abstract class AbstractMultiValueEditorFactory<T> extends AbstractEditorF
     protected abstract void configure(Text text, PropertyDescriptor<List<T>> desc, PropertySource source, ValueChangeListener listener);
 
 
-    protected abstract void setValue(Control widget, Object value);
+    protected abstract void setValue(Control widget, T value);
 
 
     protected abstract void update(PropertySource source, PropertyDescriptor<List<T>> desc, List<T> newValues);
@@ -68,7 +68,7 @@ public abstract class AbstractMultiValueEditorFactory<T> extends AbstractEditorF
     protected abstract T addValueIn(Control widget, PropertyDescriptor<List<T>> desc, PropertySource source);
 
 
-    protected abstract Control addWidget(Composite parent, Object value, PropertyDescriptor<List<T>> desc, PropertySource source);
+    protected abstract Control addWidget(Composite parent, T value, PropertyDescriptor<List<T>> desc, PropertySource source);
 
 
     public Control newEditorOn(final Composite parent, final PropertyDescriptor<List<T>> desc,

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/AbstractNumericEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/AbstractNumericEditorFactory.java
@@ -1,11 +1,5 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
-import net.sourceforge.pmd.PropertyDescriptor;
-import net.sourceforge.pmd.Rule;
-import net.sourceforge.pmd.eclipse.ui.nls.StringKeys;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -14,30 +8,27 @@ import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Spinner;
 
+import net.sourceforge.pmd.PropertyDescriptor;
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.eclipse.ui.nls.StringKeys;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
+
 /**
- *
  * @author Brian Remedios
  */
-public abstract class AbstractNumericEditorFactory extends AbstractEditorFactory {
+public abstract class AbstractNumericEditorFactory<T> extends AbstractEditorFactory<T> {
 
     public static final int defaultMinimum = 0;
     public static final int defaultMaximum = 1000;
 
+
     protected AbstractNumericEditorFactory() {
     }
 
-    protected static Spinner newSpinnerFor(Composite parent, int digits) {
 
-        Spinner spinner = new Spinner(parent, SWT.BORDER);
-        spinner.setDigits(digits);
-        return spinner;
-    }
-
-    protected int digitPrecision() {
-        return 0;
-    }
-
-    public Control[] createOtherControlsOn(Composite parent, PropertyDescriptor<?> desc, Rule rule, ValueChangeListener listener, SizeChangeListener sizeListener) {
+    public Control[] createOtherControlsOn(Composite parent, PropertyDescriptor<T> desc, Rule rule,
+                                           ValueChangeListener listener, SizeChangeListener sizeListener) {
 
         Label defaultLabel = newLabel(parent, SWTUtil.stringFor(StringKeys.RULEEDIT_LABEL_DEFAULT));
         Control valueControl = newEditorOn(parent, desc, rule, listener, sizeListener);
@@ -47,14 +38,28 @@ public abstract class AbstractNumericEditorFactory extends AbstractEditorFactory
         Label maxLabel = newLabel(parent, SWTUtil.stringFor(StringKeys.RULEEDIT_LABEL_MAX));
         Spinner maxWidget = newSpinnerFor(parent, digitPrecision());
 
-        linkup(minWidget, (Spinner)valueControl, maxWidget);
+        linkup(minWidget, (Spinner) valueControl, maxWidget);
 
         return new Control[] {
             defaultLabel, valueControl,
-            minLabel,     minWidget,
-            maxLabel,     maxWidget
-            };
+            minLabel, minWidget,
+            maxLabel, maxWidget
+        };
     }
+
+
+    protected static Spinner newSpinnerFor(Composite parent, int digits) {
+
+        Spinner spinner = new Spinner(parent, SWT.BORDER);
+        spinner.setDigits(digits);
+        return spinner;
+    }
+
+
+    protected int digitPrecision() {
+        return 0;
+    }
+
 
     private void linkup(final Spinner minWidget, final Spinner valueWidget, final Spinner maxWidget) {
         minWidget.addListener(SWT.Selection, new Listener() {
@@ -76,42 +81,60 @@ public abstract class AbstractNumericEditorFactory extends AbstractEditorFactory
         });
     }
 
+
     private void adjustForMin(Spinner minWidget, Spinner valueWidget, Spinner maxWidget) {
         int min = minWidget.getSelection();
-        if (valueWidget.getSelection() < min) valueWidget.setSelection(min);
-        if (maxWidget.getSelection() < min) maxWidget.setSelection(min);
+        if (valueWidget.getSelection() < min) {
+            valueWidget.setSelection(min);
+        }
+        if (maxWidget.getSelection() < min) {
+            maxWidget.setSelection(min);
+        }
     }
+
 
     private void adjustForValue(Spinner minWidget, Spinner valueWidget, Spinner maxWidget) {
         int value = valueWidget.getSelection();
-        if (minWidget.getSelection() > value) minWidget.setSelection(value);
-        if (maxWidget.getSelection() < value) maxWidget.setSelection(value);
+        if (minWidget.getSelection() > value) {
+            minWidget.setSelection(value);
+        }
+        if (maxWidget.getSelection() < value) {
+            maxWidget.setSelection(value);
+        }
     }
+
 
     private void adjustForMax(Spinner minWidget, Spinner valueWidget, Spinner maxWidget) {
         int max = maxWidget.getSelection();
-        if (valueWidget.getSelection() > max) valueWidget.setSelection(max);
-        if (minWidget.getSelection() > max) minWidget.setSelection(max);
+        if (valueWidget.getSelection() > max) {
+            valueWidget.setSelection(max);
+        }
+        if (minWidget.getSelection() > max) {
+            minWidget.setSelection(max);
+        }
     }
+
 
     protected Number defaultIn(Control[] controls) {
 
         return controls == null ?
-                Integer.valueOf(defaultMinimum) :
-                (Number)valueFrom(controls[1]);
+               Integer.valueOf(defaultMinimum) :
+               (Number) valueFrom(controls[1]);
     }
+
 
     protected Number minimumIn(Control[] controls) {
 
         return controls == null ?
-                Integer.valueOf(0) :
-                (Number)valueFrom(controls[3]);
+               Integer.valueOf(0) :
+               (Number) valueFrom(controls[3]);
     }
+
 
     protected Number maximumIn(Control[] controls) {
 
         return controls == null ?
-                Integer.valueOf(defaultMaximum) :
-                (Number)valueFrom(controls[5]);
+               Integer.valueOf(defaultMaximum) :
+               (Number) valueFrom(controls[5]);
     }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/AbstractRealNumberEditor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/AbstractRealNumberEditor.java
@@ -1,36 +1,38 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
-import net.sourceforge.pmd.NumericPropertyDescriptor;
-import net.sourceforge.pmd.PropertySource;
-
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Spinner;
 
+import net.sourceforge.pmd.NumericPropertyDescriptor;
+import net.sourceforge.pmd.PropertySource;
+
 /**
- *
  * @author Brian Remedios
  */
-public abstract class AbstractRealNumberEditor extends AbstractNumericEditorFactory {
+public abstract class AbstractRealNumberEditor<T extends Number> extends AbstractNumericEditorFactory<T> {
 
     protected static final int digits = 3;
 
     protected static final double scale = Math.pow(10, digits);
 
+
     protected AbstractRealNumberEditor() {
     }
 
-    protected Spinner newSpinnerFor(Composite parent, PropertySource source, NumericPropertyDescriptor<?> numDesc) {
+
+    protected Spinner newSpinnerFor(Composite parent, PropertySource source,
+                                    NumericPropertyDescriptor<T> numDesc) {
 
         Spinner spinner = newSpinnerFor(parent, digits);
-        int min = (int)(numDesc.lowerLimit().doubleValue() * scale);
-        int max = (int)(numDesc.upperLimit().doubleValue() * scale);
+        int min = (int) (numDesc.lowerLimit().doubleValue() * scale);
+        int max = (int) (numDesc.upperLimit().doubleValue() * scale);
         spinner.setMinimum(min);
         spinner.setMaximum(max);
 
-        Number value = ((Number)valueFor(source, numDesc));
+        Number value = valueFor(source, numDesc);
         if (value != null) {
-        	int intVal = (int)(value.doubleValue() * scale);
-        	spinner.setSelection(intVal);
+            int intVal = (int) (value.doubleValue() * scale);
+            spinner.setSelection(intVal);
         }
 
         return spinner;

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/AbstractRealNumberEditor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/AbstractRealNumberEditor.java
@@ -20,7 +20,7 @@ public abstract class AbstractRealNumberEditor<T extends Number> extends Abstrac
     }
 
 
-    protected Spinner newSpinnerFor(Composite parent, PropertySource source,
+    protected final Spinner newSpinnerFor(Composite parent, PropertySource source,
                                     NumericPropertyDescriptor<T> numDesc) {
 
         Spinner spinner = newSpinnerFor(parent, digits);

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/BooleanEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/BooleanEditorFactory.java
@@ -1,12 +1,5 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
-import net.sourceforge.pmd.PropertyDescriptor;
-import net.sourceforge.pmd.PropertySource;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-import net.sourceforge.pmd.lang.rule.properties.BooleanProperty;
-import net.sourceforge.pmd.lang.rule.properties.PropertyDescriptorWrapper;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -14,62 +7,63 @@ import org.eclipse.swt.widgets.Button;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
+import net.sourceforge.pmd.PropertyDescriptor;
+import net.sourceforge.pmd.PropertySource;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
+import net.sourceforge.pmd.lang.rule.properties.BooleanProperty;
+
 /**
  * @author Brian Remedios
  */
-public class BooleanEditorFactory extends AbstractEditorFactory {
+public class BooleanEditorFactory extends AbstractEditorFactory<Boolean> {
 
-	public static final BooleanEditorFactory instance = new BooleanEditorFactory();
+    public static final BooleanEditorFactory instance = new BooleanEditorFactory();
 
 
-	private BooleanEditorFactory() { }
+    private BooleanEditorFactory() { }
 
-    public PropertyDescriptor<?> createDescriptor(String name, String description, Control[] otherData) {
+
+    public PropertyDescriptor<Boolean> createDescriptor(String name, String description, Control[] otherData) {
 
         return new BooleanProperty(
-                name,
-                description,
-                otherData == null ? Boolean.FALSE : valueFrom(otherData[1]),
-                0
-                );
+            name,
+            description,
+            otherData == null ? false : valueFrom(otherData[1]),
+            0
+        );
     }
 
-    private static BooleanProperty booleanPropertyFrom(PropertyDescriptor<?> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-           return (BooleanProperty) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
-           } else {
-            return (BooleanProperty)desc;
-         }
-    }
 
     protected Boolean valueFrom(Control valueControl) {
-        return ((Button)valueControl).getSelection() ? Boolean.TRUE : Boolean.FALSE;
+        return ((Button) valueControl).getSelection();
     }
 
-   public Control newEditorOn(Composite parent, final PropertyDescriptor<?> desc, final PropertySource source, final ValueChangeListener listener, SizeChangeListener sizeListener) {
 
-       final Button butt =  new Button(parent, SWT.CHECK);
-       butt.setText("");
+    public Control newEditorOn(Composite parent, final PropertyDescriptor<Boolean> desc, final PropertySource source,
+                               final ValueChangeListener listener, SizeChangeListener sizeListener) {
 
-       final BooleanProperty bp = booleanPropertyFrom(desc);   // TODO - do I really have to do this?
+        final Button butt = new Button(parent, SWT.CHECK);
+        butt.setText("");
 
-       boolean set = ((Boolean)valueFor(source, desc)).booleanValue();
-       butt.setSelection(set);
+        boolean set = valueFor(source, desc);
+        butt.setSelection(set);
 
-       SelectionAdapter sa = new SelectionAdapter() {
-           public void widgetSelected(SelectionEvent event) {
-               boolean selected = butt.getSelection();
-               if (selected == (((Boolean)valueFor(source, bp))).booleanValue()) return;
+        SelectionAdapter sa = new SelectionAdapter() {
+            public void widgetSelected(SelectionEvent event) {
+                boolean selected = butt.getSelection();
+                if (selected == valueFor(source, desc)) {
+                    return;
+                }
 
-               source.setProperty(bp, Boolean.valueOf(selected));
-               listener.changed(source, desc, Boolean.valueOf(selected));
-               adjustRendering(source, desc, butt);
-               }
-       };
-       
-       butt.addSelectionListener(sa);
+                source.setProperty(desc, selected);
+                listener.changed(source, desc, selected);
+                adjustRendering(source, desc, butt);
+            }
+        };
 
-      return butt;
-      }
+        butt.addSelectionListener(sa);
+
+        return butt;
+    }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/CharacterEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/CharacterEditorFactory.java
@@ -1,13 +1,5 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
-import net.sourceforge.pmd.PropertyDescriptor;
-import net.sourceforge.pmd.PropertySource;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-import net.sourceforge.pmd.lang.rule.properties.CharacterProperty;
-import net.sourceforge.pmd.lang.rule.properties.PropertyDescriptorWrapper;
-import net.sourceforge.pmd.util.StringUtil;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
@@ -15,80 +7,86 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
 
+import net.sourceforge.pmd.PropertyDescriptor;
+import net.sourceforge.pmd.PropertySource;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
+import net.sourceforge.pmd.lang.rule.properties.CharacterProperty;
+import net.sourceforge.pmd.util.StringUtil;
+
 /**
- *
  * @author Brian Remedios
  */
-public class CharacterEditorFactory extends AbstractEditorFactory {
+public class CharacterEditorFactory extends AbstractEditorFactory<Character> {
 
     public static final CharacterEditorFactory instance = new CharacterEditorFactory();
 
-    private CharacterEditorFactory() {  }
 
-    public PropertyDescriptor<?> createDescriptor(String name, String description, Control[] otherData) {
+    private CharacterEditorFactory() { }
+
+
+    public PropertyDescriptor<Character> createDescriptor(String name, String description, Control[] otherData) {
 
         return new CharacterProperty(
-                name,
-                description,
-                'a',
-                0);
+            name,
+            description,
+            'a',
+            0);
     }
 
-    protected Object valueFrom(Control valueControl) {
 
-        String value = ((Text)valueControl).getText().trim();
+    protected Character valueFrom(Control valueControl) {
 
-        return (StringUtil.isEmpty(value) || value.length() > 1) ?
-                null :
-                Character.valueOf(value.charAt(0));
+        String value = ((Text) valueControl).getText().trim();
+
+        return (StringUtil.isEmpty(value) || value.length() > 1) ? null
+                                                                 : value.charAt(0);
     }
 
-    /**
-     * Method fillWidget.
-     * @param textWidget Text
-     * @param desc PropertyDescriptor<?>
-     * @param rule Rule
-     */
-    protected void fillWidget(Text textWidget, PropertyDescriptor<?> desc, PropertySource source) {
-        Character val = (Character)valueFor(source, desc);
-        textWidget.setText(val == null ? "" : val.toString());
-    }
 
-    private static Character charValueIn(Text textControl) {
-        String newValue = textControl.getText().trim();
-        if (newValue.length() == 0) return null;
-        return Character.valueOf(newValue.charAt(0));
-    }
+    public Control newEditorOn(Composite parent, final PropertyDescriptor<Character> desc, final PropertySource
+        source, final ValueChangeListener listener, SizeChangeListener sizeListener) {
 
-    private static CharacterProperty characterPropertyFrom(PropertyDescriptor<?> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-           return (CharacterProperty) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
-        } else {
-            return (CharacterProperty)desc;
-        }
-    }
-
-    public Control newEditorOn(Composite parent, final PropertyDescriptor<?> desc, final PropertySource source, final ValueChangeListener listener, SizeChangeListener sizeListener) {
-
-        final Text text =  new Text(parent, SWT.SINGLE | SWT.BORDER);
+        final Text text = new Text(parent, SWT.SINGLE | SWT.BORDER);
 
         fillWidget(text, desc, source);
-
-        final CharacterProperty cp = characterPropertyFrom(desc); // TODO - really necessary?
 
         text.addListener(SWT.FocusOut, new Listener() {
             public void handleEvent(Event event) {
                 Character newValue = charValueIn(text);
-                Character existingValue = (Character)valueFor(source, cp);
-                if (existingValue.equals(newValue)) return;
-
-                source.setProperty(cp, newValue);
-                listener.changed(source, cp, newValue);
-                adjustRendering(source, desc, text);
+                Character existingValue = valueFor(source, desc);
+                if (existingValue.equals(newValue)) {
+                    return;
                 }
-            });
+
+                source.setProperty(desc, newValue);
+                listener.changed(source, desc, newValue);
+                adjustRendering(source, desc, text);
+            }
+        });
 
         return text;
+    }
+
+
+    /**
+     * Method fillWidget.
+     *
+     * @param textWidget Text
+     * @param desc       PropertyDescriptor<?>
+     * @param rule       Rule
+     */
+    protected void fillWidget(Text textWidget, PropertyDescriptor<Character> desc, PropertySource source) {
+        Character val = valueFor(source, desc);
+        textWidget.setText(val == null ? "" : val.toString());
+    }
+
+
+    private static Character charValueIn(Text textControl) {
+        String newValue = textControl.getText().trim();
+        if (newValue.length() == 0) {
+            return null;
         }
+        return newValue.charAt(0);
+    }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/CharacterEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/CharacterEditorFactory.java
@@ -74,7 +74,6 @@ public class CharacterEditorFactory extends AbstractEditorFactory<Character> {
      *
      * @param textWidget Text
      * @param desc       PropertyDescriptor<?>
-     * @param rule       Rule
      */
     protected void fillWidget(Text textWidget, PropertyDescriptor<Character> desc, PropertySource source) {
         Character val = valueFor(source, desc);

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/DoubleEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/DoubleEditorFactory.java
@@ -5,7 +5,7 @@ import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
 import net.sourceforge.pmd.lang.rule.properties.DoubleProperty;
-import net.sourceforge.pmd.lang.rule.properties.PropertyDescriptorWrapper;
+import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/DoubleEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/DoubleEditorFactory.java
@@ -6,43 +6,34 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Spinner;
 
+import net.sourceforge.pmd.NumericPropertyDescriptor;
 import net.sourceforge.pmd.PropertyDescriptor;
 import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
 import net.sourceforge.pmd.lang.rule.properties.DoubleProperty;
-import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 
 /**
- *
  * @author Brian Remedios
  */
 public class DoubleEditorFactory extends AbstractRealNumberEditor<Double> {
 
-	public static final DoubleEditorFactory instance = new DoubleEditorFactory();
+    public static final DoubleEditorFactory instance = new DoubleEditorFactory();
 
-	private DoubleEditorFactory() { }
+
+    private DoubleEditorFactory() { }
 
 
     public PropertyDescriptor<Double> createDescriptor(String name, String description, Control[] otherData) {
 
         return new DoubleProperty(
-                name,
-                description,
-                defaultIn(otherData).doubleValue(),
-                minimumIn(otherData).doubleValue(),
-                maximumIn(otherData).doubleValue(),
-                0.0f
-                );
-    }
-
-    private static DoubleProperty doublePropertyFrom(PropertyDescriptor<?> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-           return (DoubleProperty) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
-        } else {
-            return (DoubleProperty)desc;
-        }
+            name,
+            description,
+            defaultIn(otherData).doubleValue(),
+            minimumIn(otherData).doubleValue(),
+            maximumIn(otherData).doubleValue(),
+            0.0f
+        );
     }
 
 
@@ -55,21 +46,22 @@ public class DoubleEditorFactory extends AbstractRealNumberEditor<Double> {
     public Control newEditorOn(Composite parent, final PropertyDescriptor<Double> desc, final PropertySource source,
                                final ValueChangeListener listener, SizeChangeListener sizeListener) {
 
-        final DoubleProperty dp = doublePropertyFrom(desc);
-        final Spinner spinner = newSpinnerFor(parent, source, dp);
+        final Spinner spinner = newSpinnerFor(parent, source, (NumericPropertyDescriptor<Double>) desc);
 
         spinner.addModifyListener(new ModifyListener() {
-	           public void modifyText(ModifyEvent event) {
-                   Double newValue = spinner.getSelection() / scale;
-                if (newValue.equals(valueFor(source, dp))) return;
+            public void modifyText(ModifyEvent event) {
+                Double newValue = spinner.getSelection() / scale;
+                if (newValue.equals(valueFor(source, desc))) {
+                    return;
+                }
 
-                source.setProperty(dp, newValue);
-                listener.changed(source, dp, newValue);
+                source.setProperty(desc, newValue);
+                listener.changed(source, desc, newValue);
 
                 adjustRendering(source, desc, spinner);
-             }
-         });
+            }
+        });
 
         return spinner;
-     }
+    }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/DoubleEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/DoubleEditorFactory.java
@@ -1,5 +1,11 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Spinner;
+
 import net.sourceforge.pmd.PropertyDescriptor;
 import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
@@ -7,23 +13,18 @@ import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
 import net.sourceforge.pmd.lang.rule.properties.DoubleProperty;
 import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 
-import org.eclipse.swt.events.ModifyEvent;
-import org.eclipse.swt.events.ModifyListener;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Spinner;
-
 /**
  *
  * @author Brian Remedios
  */
-public class DoubleEditorFactory extends AbstractRealNumberEditor {
+public class DoubleEditorFactory extends AbstractRealNumberEditor<Double> {
 
 	public static final DoubleEditorFactory instance = new DoubleEditorFactory();
 
 	private DoubleEditorFactory() { }
 
-    public PropertyDescriptor<?> createDescriptor(String name, String description, Control[] otherData) {
+
+    public PropertyDescriptor<Double> createDescriptor(String name, String description, Control[] otherData) {
 
         return new DoubleProperty(
                 name,
@@ -44,19 +45,22 @@ public class DoubleEditorFactory extends AbstractRealNumberEditor {
         }
     }
 
-    protected Object valueFrom(Control valueControl) {
 
-        return Double.valueOf(((Spinner)valueControl).getSelection() / scale);
+    protected Double valueFrom(Control valueControl) {
+
+        return ((Spinner) valueControl).getSelection() / scale;
     }
 
-	public Control newEditorOn(Composite parent, final PropertyDescriptor<?> desc, final PropertySource source, final ValueChangeListener listener, SizeChangeListener sizeListener) {
+
+    public Control newEditorOn(Composite parent, final PropertyDescriptor<Double> desc, final PropertySource source,
+                               final ValueChangeListener listener, SizeChangeListener sizeListener) {
 
         final DoubleProperty dp = doublePropertyFrom(desc);
         final Spinner spinner = newSpinnerFor(parent, source, dp);
 
         spinner.addModifyListener(new ModifyListener() {
 	           public void modifyText(ModifyEvent event) {
-                Double newValue = Double.valueOf(spinner.getSelection() / scale);
+                   Double newValue = spinner.getSelection() / scale;
                 if (newValue.equals(valueFor(source, dp))) return;
 
                 source.setProperty(dp, newValue);

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/EnumerationEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/EnumerationEditorFactory.java
@@ -7,12 +7,12 @@ import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
+import net.sourceforge.pmd.EnumeratedPropertyDescriptor;
 import net.sourceforge.pmd.PropertyDescriptor;
 import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
 import net.sourceforge.pmd.lang.rule.properties.EnumeratedProperty;
-import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 
 /**
  * @author Brian Remedios
@@ -42,7 +42,7 @@ public class EnumerationEditorFactory extends AbstractEditorFactory<Object> {
 
         final Combo combo = new Combo(parent, SWT.READ_ONLY);
 
-        final EnumeratedProperty<Object> ep = enumerationPropertyFrom(desc);
+        final EnumeratedPropertyDescriptor<Object, Object> ep = (EnumeratedPropertyDescriptor<Object, Object>) desc;
         Object value = valueFor(source, desc);
         combo.setItems(SWTUtil.labelsIn(ep.choices(), 0));
         int selectionIdx = indexOf(value, ep.choices());
@@ -65,16 +65,6 @@ public class EnumerationEditorFactory extends AbstractEditorFactory<Object> {
         });
 
         return combo;
-    }
-
-
-    private static EnumeratedProperty<Object> enumerationPropertyFrom(PropertyDescriptor<Object> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-            return (EnumeratedProperty<Object>) ((PropertyDescriptorWrapper<Object>) desc).getPropertyDescriptor();
-        } else {
-            return (EnumeratedProperty<Object>) desc;
-        }
     }
 
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/EnumerationEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/EnumerationEditorFactory.java
@@ -1,12 +1,5 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
-import net.sourceforge.pmd.PropertyDescriptor;
-import net.sourceforge.pmd.PropertySource;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-import net.sourceforge.pmd.lang.rule.properties.EnumeratedProperty;
-import net.sourceforge.pmd.lang.rule.properties.PropertyDescriptorWrapper;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -14,73 +7,92 @@ import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 
+import net.sourceforge.pmd.PropertyDescriptor;
+import net.sourceforge.pmd.PropertySource;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
+import net.sourceforge.pmd.lang.rule.properties.EnumeratedProperty;
+import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
+
 /**
- *
  * @author Brian Remedios
  */
-public class EnumerationEditorFactory extends AbstractEditorFactory {
+public class EnumerationEditorFactory extends AbstractEditorFactory<Object> {
 
     public static final EnumerationEditorFactory instance = new EnumerationEditorFactory();
 
+
     private EnumerationEditorFactory() { }
-
-    private static EnumeratedProperty<?> enumerationPropertyFrom(PropertyDescriptor<?> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-           return (EnumeratedProperty<?>) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
-        } else {
-            return (EnumeratedProperty<?>)desc;
-        }
-    }
 
 
     protected Object valueFrom(Control valueControl) {
 
-        int index = ((Combo)valueControl).getSelectionIndex();
+        int index = ((Combo) valueControl).getSelectionIndex();
         return null;    // TODO ???
     }
 
-    public PropertyDescriptor<?> createDescriptor(String name, String optionalDescription, Control[] otherData) {
-        return new EnumeratedProperty(name, "Value set " + name, null, null, 0, 0.0f);
+
+    public PropertyDescriptor<Object> createDescriptor(String name, String optionalDescription, Control[] otherData) {
+        return new EnumeratedProperty<Object>(name, "Value set " + name, null, null, 0, Object.class, 0.0f);
     }
+
+
+    public Control newEditorOn(Composite parent, final PropertyDescriptor<Object> desc, final PropertySource source,
+                               final ValueChangeListener listener, SizeChangeListener sizeListener) {
+
+        final Combo combo = new Combo(parent, SWT.READ_ONLY);
+
+        final EnumeratedProperty<Object> ep = enumerationPropertyFrom(desc);
+        Object value = valueFor(source, desc);
+        combo.setItems(SWTUtil.labelsIn(ep.choices(), 0));
+        int selectionIdx = indexOf(value, ep.choices());
+        if (selectionIdx >= 0) {
+            combo.select(selectionIdx);
+        }
+
+        combo.addSelectionListener(new SelectionAdapter() {
+            public void widgetSelected(SelectionEvent e) {
+                int selectionIdx = combo.getSelectionIndex();
+                Object newValue = ep.choices()[selectionIdx][1];
+                if (newValue == valueFor(source, desc)) {
+                    return;
+                }
+
+                source.setProperty(ep, newValue);
+                listener.changed(source, desc, newValue);
+                adjustRendering(source, desc, combo);
+            }
+        });
+
+        return combo;
+    }
+
+
+    private static EnumeratedProperty<Object> enumerationPropertyFrom(PropertyDescriptor<Object> desc) {
+
+        if (desc instanceof PropertyDescriptorWrapper<?>) {
+            return (EnumeratedProperty<Object>) ((PropertyDescriptorWrapper<Object>) desc).getPropertyDescriptor();
+        } else {
+            return (EnumeratedProperty<Object>) desc;
+        }
+    }
+
 
     /**
      * Search through both columns if necessary
      */
     public static int indexOf(Object item, Object[][] items) {
-    	int index = indexOf(item, items, 0);
-    	return index < 0 ? indexOf(item, items, 1) : index;
+        int index = indexOf(item, items, 0);
+        return index < 0 ? indexOf(item, items, 1) : index;
     }
-    
+
+
     public static int indexOf(Object item, Object[][] items, int testColumnIndex) {
-        for (int i=0; i<items.length; i++) {
-        	if (items[i][testColumnIndex].equals(item)) return i;
+        for (int i = 0; i < items.length; i++) {
+            if (items[i][testColumnIndex].equals(item)) {
+                return i;
+            }
         }
         return -1;
     }
-
-    public Control newEditorOn(Composite parent, final PropertyDescriptor<?> desc, final PropertySource source, final ValueChangeListener listener, SizeChangeListener sizeListener) {
-
-            final Combo combo = new Combo(parent, SWT.READ_ONLY);
-
-            final EnumeratedProperty<?> ep = enumerationPropertyFrom(desc);
-            Object value = valueFor(source, desc);
-            combo.setItems(SWTUtil.labelsIn(ep.choices(), 0));
-            int selectionIdx = indexOf(value, ep.choices());            
-            if (selectionIdx >= 0) combo.select(selectionIdx);
-
-            combo.addSelectionListener(new SelectionAdapter() {
-                public void widgetSelected(SelectionEvent e) {
-                    int selectionIdx = combo.getSelectionIndex();
-                    Object newValue = ep.choices()[selectionIdx][1];
-                    if (newValue == valueFor(source, desc)) return;
-
-                    source.setProperty(ep, newValue);
-                    listener.changed(source, desc, newValue);
-                    adjustRendering(source, desc, combo);
-                }
-              });
-
-            return combo;
-        }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/EnumerationEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/EnumerationEditorFactory.java
@@ -1,5 +1,7 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
+import java.util.Map.Entry;
+
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
@@ -44,8 +46,8 @@ public class EnumerationEditorFactory extends AbstractEditorFactory<Object> {
 
         final EnumeratedPropertyDescriptor<Object, Object> ep = (EnumeratedPropertyDescriptor<Object, Object>) desc;
         Object value = valueFor(source, desc);
-        combo.setItems(SWTUtil.labelsIn(ep.choices(), 0));
-        int selectionIdx = indexOf(value, ep.choices());
+        combo.setItems(SWTUtil.labelsIn(choices(ep), 0));
+        int selectionIdx = indexOf(value, choices(ep));
         if (selectionIdx >= 0) {
             combo.select(selectionIdx);
         }
@@ -53,7 +55,7 @@ public class EnumerationEditorFactory extends AbstractEditorFactory<Object> {
         combo.addSelectionListener(new SelectionAdapter() {
             public void widgetSelected(SelectionEvent e) {
                 int selectionIdx = combo.getSelectionIndex();
-                Object newValue = ep.choices()[selectionIdx][1];
+                Object newValue = choices(ep)[selectionIdx][1];
                 if (newValue == valueFor(source, desc)) {
                     return;
                 }
@@ -84,5 +86,15 @@ public class EnumerationEditorFactory extends AbstractEditorFactory<Object> {
             }
         }
         return -1;
+    }
+
+    public static <E, T> Object[][] choices(EnumeratedPropertyDescriptor<E, T> prop) {
+        Object[][] res = new Object[prop.mappings().size()][2];
+        int i = 0;
+        for (Entry<String, E> e : prop.mappings().entrySet()) {
+            res[i++][0] = e.getKey();
+            res[i][1] = e.getValue();
+        }
+        return res;
     }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/FileEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/FileEditorFactory.java
@@ -2,13 +2,6 @@ package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
 import java.io.File;
 
-import net.sourceforge.pmd.PropertyDescriptor;
-import net.sourceforge.pmd.PropertySource;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-import net.sourceforge.pmd.lang.rule.properties.FileProperty;
-import net.sourceforge.pmd.lang.rule.properties.PropertyDescriptorWrapper;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
@@ -16,73 +9,52 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
+import net.sourceforge.pmd.PropertyDescriptor;
+import net.sourceforge.pmd.PropertySource;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
+import net.sourceforge.pmd.lang.rule.properties.FileProperty;
+
 /**
-*
-* @author Brian Remedios
-*/
-public class FileEditorFactory extends AbstractEditorFactory {
+ * @author Brian Remedios
+ */
+public class FileEditorFactory extends AbstractEditorFactory<File> {
 
 
-	public static final FileEditorFactory instance = new FileEditorFactory();
-	
-	protected FileEditorFactory() {	}
+    public static final FileEditorFactory instance = new FileEditorFactory();
 
-    public PropertyDescriptor<?> createDescriptor(String name, String description, Control[] otherData) {
+
+    protected FileEditorFactory() { }
+
+
+    public PropertyDescriptor<File> createDescriptor(String name, String description, Control[] otherData) {
 
         return new FileProperty(
-                name,
-                description,
-                new File(""),
-                0.0f
-                );
+            name,
+            description,
+            new File(""),
+            0.0f
+        );
     }
 
-	private static FileProperty filePropertyFrom(PropertyDescriptor<?> desc) {
 
-	    if (desc instanceof PropertyDescriptorWrapper<?>) {
-	       return (FileProperty) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
-	       } else {
-	        return (FileProperty)desc;
-	     }
-	}
-	
-	private void setValue(PropertySource source, FileProperty desc, File value) {
+    public Control newEditorOn(Composite parent, final PropertyDescriptor<File> desc, final PropertySource source,
+                               final ValueChangeListener listener, SizeChangeListener sizeListener) {
 
-	    if (!source.hasDescriptor(desc)) return;
-	    source.setProperty(desc, value);
-	}
-	
-	public static boolean areSemanticEquals(File fileA, File fileB) {
-		if (fileA == fileB) return true;
-		
-		if (fileA == null && fileB != null) return false;
-		if (fileA != null && fileB == null) return false;
-		
-		return fileA.equals(fileB);
-	}
-	
-	protected void fillWidget(FilePicker fileWidget, PropertyDescriptor<?> desc, PropertySource source) {
-		File val = (File)valueFor(source, desc);
-		fileWidget.setFile(val == null ? null : val);
-		adjustRendering(source, desc, fileWidget);
-	}
-	
-	public Control newEditorOn(Composite parent, final PropertyDescriptor<?> desc, final PropertySource source, final ValueChangeListener listener, SizeChangeListener sizeListener) {
-       
-		final FilePicker picker =  new FilePicker(parent, SWT.SINGLE | SWT.BORDER, "Open", null);
+        final FilePicker picker = new FilePicker(parent, SWT.SINGLE | SWT.BORDER, "Open", null);
         picker.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
         fillWidget(picker, desc, source);
 
-        final FileProperty fp = filePropertyFrom(desc); // TODO - really necessary?
-
         picker.addFocusOutListener(new Listener() {
             public void handleEvent(Event event) {
                 File newValue = picker.getFile();
-                File existingValue = (File)valueFor(source, fp);
-                if (areSemanticEquals(existingValue, newValue)) return;
+                File existingValue = valueFor(source, desc);
+                if (areSemanticEquals(existingValue, newValue)) {
+                    return;
+                }
 
-                setValue(source, fp, newValue);
+                setValue(source, desc, newValue);
                 fillWidget(picker, desc, source);     // redraw
                 listener.changed(source, desc, newValue);
             }
@@ -91,9 +63,31 @@ public class FileEditorFactory extends AbstractEditorFactory {
         return picker;
     }
 
-	@Override
-	protected Object valueFrom(Control valueControl) {
-		 return ((FilePicker)valueControl).getFile();
-	}
+
+    protected void fillWidget(FilePicker fileWidget, PropertyDescriptor<File> desc, PropertySource source) {
+        File val = valueFor(source, desc);
+        fileWidget.setFile(val);
+        adjustRendering(source, desc, fileWidget);
+    }
+
+
+    public static boolean areSemanticEquals(File fileA, File fileB) {
+        return fileA == fileB || fileA != null && fileB != null && fileA.equals(fileB);
+    }
+
+
+    private void setValue(PropertySource source, PropertyDescriptor<File> desc, File value) {
+
+        if (!source.hasDescriptor(desc)) {
+            return;
+        }
+        source.setProperty(desc, value);
+    }
+
+
+    @Override
+    protected File valueFrom(Control valueControl) {
+        return ((FilePicker) valueControl).getFile();
+    }
 
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/FloatEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/FloatEditorFactory.java
@@ -5,7 +5,7 @@ import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
 import net.sourceforge.pmd.lang.rule.properties.FloatProperty;
-import net.sourceforge.pmd.lang.rule.properties.PropertyDescriptorWrapper;
+import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/FloatEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/FloatEditorFactory.java
@@ -1,5 +1,11 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
+import org.eclipse.swt.events.ModifyEvent;
+import org.eclipse.swt.events.ModifyListener;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Spinner;
+
 import net.sourceforge.pmd.PropertyDescriptor;
 import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
@@ -7,65 +13,66 @@ import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
 import net.sourceforge.pmd.lang.rule.properties.FloatProperty;
 import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 
-import org.eclipse.swt.events.ModifyEvent;
-import org.eclipse.swt.events.ModifyListener;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Spinner;
-
 /**
- *
  * @author Brian Remedios
  */
-public class FloatEditorFactory extends AbstractRealNumberEditor {
+public class FloatEditorFactory extends AbstractRealNumberEditor<Float> {
 
-	public static final FloatEditorFactory instance = new FloatEditorFactory();
+    public static final FloatEditorFactory instance = new FloatEditorFactory();
 
-	private FloatEditorFactory() { }
 
-    public PropertyDescriptor<?> createDescriptor(String name, String description, Control[] otherData) {
+    private FloatEditorFactory() { }
+
+
+    public PropertyDescriptor<Float> createDescriptor(String name, String description, Control[] otherData) {
 
         return new FloatProperty(
-                name,
-                description,
-                defaultIn(otherData).floatValue(),
-                minimumIn(otherData).floatValue(),
-                maximumIn(otherData).floatValue(),
-                0.0f
-                );
+            name,
+            description,
+            defaultIn(otherData).floatValue(),
+            minimumIn(otherData).floatValue(),
+            maximumIn(otherData).floatValue(),
+            0.0f
+        );
     }
 
-    private static FloatProperty floatPropertyFrom(PropertyDescriptor<?> desc) {
 
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-           return (FloatProperty) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
-        } else {
-            return (FloatProperty)desc;
-        }
+    protected Float valueFrom(Control valueControl) {
+
+        return (float) (((Spinner) valueControl).getSelection() / scale);
     }
 
-    protected Object valueFrom(Control valueControl) {
 
-        return new Float(((Spinner)valueControl).getSelection() / scale);
-    }
-
-	public Control newEditorOn(Composite parent, final PropertyDescriptor<?> desc, final PropertySource source, final ValueChangeListener listener, SizeChangeListener sizeListener) {
+    public Control newEditorOn(Composite parent, final PropertyDescriptor<Float> desc, final PropertySource source,
+                               final ValueChangeListener listener, SizeChangeListener sizeListener) {
 
         final FloatProperty fp = floatPropertyFrom(desc);
         final Spinner spinner = newSpinnerFor(parent, source, fp);
 
         spinner.addModifyListener(new ModifyListener() {
-	        public void modifyText(ModifyEvent event) {
-               Float newValue = new Float(spinner.getSelection() / scale);
-               if (newValue.equals(valueFor(source, fp))) return;
+            public void modifyText(ModifyEvent event) {
+                Float newValue = (float) (spinner.getSelection() / scale);
+                if (newValue.equals(valueFor(source, fp))) {
+                    return;
+                }
 
-               source.setProperty(fp, newValue);
-               listener.changed(source, fp, newValue);
+                source.setProperty(fp, newValue);
+                listener.changed(source, fp, newValue);
 
-               adjustRendering(source, desc, spinner);
-               }
-           });
+                adjustRendering(source, desc, spinner);
+            }
+        });
 
         return spinner;
+    }
+
+
+    private static FloatProperty floatPropertyFrom(PropertyDescriptor<?> desc) {
+
+        if (desc instanceof PropertyDescriptorWrapper<?>) {
+            return (FloatProperty) ((PropertyDescriptorWrapper<?>) desc).getPropertyDescriptor();
+        } else {
+            return (FloatProperty) desc;
         }
+    }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/FloatEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/FloatEditorFactory.java
@@ -6,12 +6,12 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Spinner;
 
+import net.sourceforge.pmd.NumericPropertyDescriptor;
 import net.sourceforge.pmd.PropertyDescriptor;
 import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
 import net.sourceforge.pmd.lang.rule.properties.FloatProperty;
-import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 
 /**
  * @author Brian Remedios
@@ -46,18 +46,17 @@ public class FloatEditorFactory extends AbstractRealNumberEditor<Float> {
     public Control newEditorOn(Composite parent, final PropertyDescriptor<Float> desc, final PropertySource source,
                                final ValueChangeListener listener, SizeChangeListener sizeListener) {
 
-        final FloatProperty fp = floatPropertyFrom(desc);
-        final Spinner spinner = newSpinnerFor(parent, source, fp);
+        final Spinner spinner = newSpinnerFor(parent, source, (NumericPropertyDescriptor<Float>) desc);
 
         spinner.addModifyListener(new ModifyListener() {
             public void modifyText(ModifyEvent event) {
                 Float newValue = (float) (spinner.getSelection() / scale);
-                if (newValue.equals(valueFor(source, fp))) {
+                if (newValue.equals(valueFor(source, desc))) {
                     return;
                 }
 
-                source.setProperty(fp, newValue);
-                listener.changed(source, fp, newValue);
+                source.setProperty(desc, newValue);
+                listener.changed(source, desc, newValue);
 
                 adjustRendering(source, desc, spinner);
             }
@@ -67,12 +66,4 @@ public class FloatEditorFactory extends AbstractRealNumberEditor<Float> {
     }
 
 
-    private static FloatProperty floatPropertyFrom(PropertyDescriptor<?> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-            return (FloatProperty) ((PropertyDescriptorWrapper<?>) desc).getPropertyDescriptor();
-        } else {
-            return (FloatProperty) desc;
-        }
-    }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/IntegerEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/IntegerEditorFactory.java
@@ -12,7 +12,6 @@ import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
 import net.sourceforge.pmd.lang.rule.properties.IntegerProperty;
-import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 
 /**
  * @author Brian Remedios
@@ -46,34 +45,22 @@ public class IntegerEditorFactory extends AbstractNumericEditorFactory<Integer> 
     public Control newEditorOn(Composite parent, final PropertyDescriptor<Integer> desc, final PropertySource source,
                                final ValueChangeListener listener, SizeChangeListener sizeListener) {
 
-        final IntegerProperty ip = intPropertyFrom(desc);   // TODO - do I really have to do this?
-
-        final Spinner spinner = newSpinner(parent, ip, valueFor(source, desc));
+        final Spinner spinner = newSpinner(parent, (NumericPropertyDescriptor<Integer>) desc, valueFor(source, desc));
 
         spinner.addModifyListener(new ModifyListener() {
             public void modifyText(ModifyEvent event) {
                 Integer newValue = spinner.getSelection();
-                if (newValue.equals(valueFor(source, ip))) {
+                if (newValue.equals(valueFor(source, desc))) {
                     return;
                 }
 
-                setValue(source, ip, newValue);
+                source.setProperty(desc, newValue);
                 listener.changed(source, desc, newValue);
                 adjustRendering(source, desc, spinner);
             }
         });
 
         return spinner;
-    }
-
-
-    private static IntegerProperty intPropertyFrom(PropertyDescriptor<Integer> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-            return (IntegerProperty) ((PropertyDescriptorWrapper<Integer>) desc).getPropertyDescriptor();
-        } else {
-            return (IntegerProperty) desc;
-        }
     }
 
 
@@ -89,10 +76,4 @@ public class IntegerEditorFactory extends AbstractNumericEditorFactory<Integer> 
         return spinner;
     }
 
-
-    protected void setValue(PropertySource source, IntegerProperty desc, Integer value) {
-
-//	    if (!rule.hasDescriptor(desc)) return;
-        source.setProperty(desc, value);
-    }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/IntegerEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/IntegerEditorFactory.java
@@ -1,91 +1,98 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
-import net.sourceforge.pmd.NumericPropertyDescriptor;
-import net.sourceforge.pmd.PropertyDescriptor;
-import net.sourceforge.pmd.PropertySource;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-import net.sourceforge.pmd.lang.rule.properties.IntegerProperty;
-import net.sourceforge.pmd.lang.rule.properties.PropertyDescriptorWrapper;
-
 import org.eclipse.swt.events.ModifyEvent;
 import org.eclipse.swt.events.ModifyListener;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Spinner;
 
+import net.sourceforge.pmd.NumericPropertyDescriptor;
+import net.sourceforge.pmd.PropertyDescriptor;
+import net.sourceforge.pmd.PropertySource;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
+import net.sourceforge.pmd.lang.rule.properties.IntegerProperty;
+import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
+
 /**
- *
  * @author Brian Remedios
  */
-public class IntegerEditorFactory extends AbstractNumericEditorFactory {
+public class IntegerEditorFactory extends AbstractNumericEditorFactory<Integer> {
 
-	public static final IntegerEditorFactory instance = new IntegerEditorFactory();
+    public static final IntegerEditorFactory instance = new IntegerEditorFactory();
 
-	private IntegerEditorFactory() { }
 
-    public PropertyDescriptor<?> createDescriptor(String name, String description, Control[] otherData) {
+    private IntegerEditorFactory() { }
+
+
+    public PropertyDescriptor<Integer> createDescriptor(String name, String description, Control[] otherData) {
 
         return new IntegerProperty(
-                name,
-                description,
-                minimumIn(otherData).intValue(),
-                maximumIn(otherData).intValue(),
-                defaultIn(otherData).intValue(),
-                0.0f
-                );
+            name,
+            description,
+            minimumIn(otherData).intValue(),
+            maximumIn(otherData).intValue(),
+            defaultIn(otherData).intValue(),
+            0.0f
+        );
     }
 
-    protected Object valueFrom(Control valueControl) {
 
-        int value = ((Spinner)valueControl).getSelection();
-        return Integer.valueOf(value);
+    protected Integer valueFrom(Control valueControl) {
+        return ((Spinner) valueControl).getSelection();
     }
 
-	private static IntegerProperty intPropertyFrom(PropertyDescriptor<?> desc) {
 
-	    if (desc instanceof PropertyDescriptorWrapper<?>) {
-           return (IntegerProperty) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
+    public Control newEditorOn(Composite parent, final PropertyDescriptor<Integer> desc, final PropertySource source,
+                               final ValueChangeListener listener, SizeChangeListener sizeListener) {
+
+        final IntegerProperty ip = intPropertyFrom(desc);   // TODO - do I really have to do this?
+
+        final Spinner spinner = newSpinner(parent, ip, valueFor(source, desc));
+
+        spinner.addModifyListener(new ModifyListener() {
+            public void modifyText(ModifyEvent event) {
+                Integer newValue = spinner.getSelection();
+                if (newValue.equals(valueFor(source, ip))) {
+                    return;
+                }
+
+                setValue(source, ip, newValue);
+                listener.changed(source, desc, newValue);
+                adjustRendering(source, desc, spinner);
+            }
+        });
+
+        return spinner;
+    }
+
+
+    private static IntegerProperty intPropertyFrom(PropertyDescriptor<Integer> desc) {
+
+        if (desc instanceof PropertyDescriptorWrapper<?>) {
+            return (IntegerProperty) ((PropertyDescriptorWrapper<Integer>) desc).getPropertyDescriptor();
         } else {
-            return (IntegerProperty)desc;
+            return (IntegerProperty) desc;
         }
-	}
+    }
 
-	public static Spinner newSpinner(Composite parent, NumericPropertyDescriptor<?> desc, Object valueIn) {
 
-	    Spinner spinner = newSpinnerFor(parent, 0);
+    public static Spinner newSpinner(Composite parent, NumericPropertyDescriptor<Integer> desc, Object valueIn) {
+
+        Spinner spinner = newSpinnerFor(parent, 0);
 
         spinner.setMinimum(desc.lowerLimit().intValue());
         spinner.setMaximum(desc.upperLimit().intValue());
 
-        int value = valueIn == null ? spinner.getMinimum() : ((Number)valueIn).intValue();
+        int value = valueIn == null ? spinner.getMinimum() : ((Number) valueIn).intValue();
         spinner.setSelection(value);
         return spinner;
-	}
+    }
 
-	protected void setValue(PropertySource source, IntegerProperty desc, Integer value) {
+
+    protected void setValue(PropertySource source, IntegerProperty desc, Integer value) {
 
 //	    if (!rule.hasDescriptor(desc)) return;
-		source.setProperty(desc, value);
-	}
-
-	public Control newEditorOn(Composite parent, final PropertyDescriptor<?> desc, final PropertySource source, final ValueChangeListener listener, SizeChangeListener sizeListener) {
-
-	      final IntegerProperty ip = intPropertyFrom(desc);   // TODO - do I really have to do this?
-
-	      final Spinner spinner = newSpinner(parent, ip, valueFor(source, desc));
-
-	      spinner.addModifyListener(new ModifyListener() {
-	           public void modifyText(ModifyEvent event) {
-	                Integer newValue = Integer.valueOf(spinner.getSelection());
-	                if (newValue.equals(valueFor(source, ip))) return;
-
-	                setValue(source, ip, newValue);
-	                listener.changed(source, desc, newValue);
-	                adjustRendering(source, desc, spinner);
-	                }
-	            });
-
-	       return spinner;
-	   }
+        source.setProperty(desc, value);
+    }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/IntegerEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/IntegerEditorFactory.java
@@ -77,7 +77,7 @@ public class IntegerEditorFactory extends AbstractNumericEditorFactory<Integer> 
     }
 
 
-    public static Spinner newSpinner(Composite parent, NumericPropertyDescriptor<Integer> desc, Object valueIn) {
+    public static Spinner newSpinner(Composite parent, NumericPropertyDescriptor<?> desc, Object valueIn) {
 
         Spinner spinner = newSpinnerFor(parent, 0);
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MethodEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MethodEditorFactory.java
@@ -2,6 +2,13 @@ package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
 import java.lang.reflect.Method;
 
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+
 import net.sourceforge.pmd.PropertyDescriptor;
 import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
@@ -10,18 +17,11 @@ import net.sourceforge.pmd.lang.rule.properties.MethodProperty;
 import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 import net.sourceforge.pmd.util.ClassUtil;
 
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.events.SelectionAdapter;
-import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.layout.GridData;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-
 /**
  *
  * @author Brian Remedios
  */
-public class MethodEditorFactory extends AbstractEditorFactory {
+public class MethodEditorFactory extends AbstractEditorFactory<Method> {
 
 	public static final MethodEditorFactory instance = new MethodEditorFactory();
 	public static final String[] UnwantedPrefixes = new String[] {
@@ -34,32 +34,20 @@ public class MethodEditorFactory extends AbstractEditorFactory {
 
 	private MethodEditorFactory() { }
 
-    public PropertyDescriptor<?> createDescriptor(String name, String optionalDescription, Control[] otherData) {
+
+    public PropertyDescriptor<Method> createDescriptor(String name, String optionalDescription, Control[] otherData) {
         return new MethodProperty(name, "Method value " + name, stringLength, new String[] { "java.lang" }, 0.0f);
     }
 
-    protected Object valueFrom(Control valueControl) {
+
+    protected Method valueFrom(Control valueControl) {
 
         return ((MethodPicker)valueControl).getMethod();
     }
 
-	protected void fillWidget(MethodPicker widget, PropertyDescriptor<?> desc, PropertySource source) {
 
-		Method method = (Method)valueFor(source, desc);
-		widget.setMethod(method);
-        adjustRendering(source, desc, widget);
-	}
-
-    private static MethodProperty methodPropertyFrom(PropertyDescriptor<?> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-           return (MethodProperty) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
-        } else {
-            return (MethodProperty)desc;
-        }
-    }
-
-    public Control newEditorOn(Composite parent, final PropertyDescriptor<?> desc, final PropertySource source, final ValueChangeListener listener, SizeChangeListener sizeListener) {
+    public Control newEditorOn(Composite parent, final PropertyDescriptor<Method> desc, final PropertySource source,
+                               final ValueChangeListener listener, SizeChangeListener sizeListener) {
 
         final MethodPicker picker = new MethodPicker(parent, SWT.SINGLE | SWT.BORDER, UnwantedPrefixes);
         picker.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
@@ -73,7 +61,7 @@ public class MethodEditorFactory extends AbstractEditorFactory {
                 Method newValue = picker.getMethod();
                 if (newValue == null) return;
 
-                Method existingValue = (Method)valueFor(source, mp);
+                Method existingValue = valueFor(source, mp);
                 if (existingValue == newValue) return;
 
                 source.setProperty(mp, newValue);
@@ -84,4 +72,21 @@ public class MethodEditorFactory extends AbstractEditorFactory {
 
         return picker;
     }
+
+    private static MethodProperty methodPropertyFrom(PropertyDescriptor<?> desc) {
+
+        if (desc instanceof PropertyDescriptorWrapper<?>) {
+           return (MethodProperty) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
+        } else {
+            return (MethodProperty)desc;
+        }
+    }
+
+
+    protected void fillWidget(MethodPicker widget, PropertyDescriptor<Method> desc, PropertySource source) {
+
+        Method method = valueFor(source, desc);
+        widget.setMethod(method);
+        adjustRendering(source, desc, widget);
+	}
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MethodEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MethodEditorFactory.java
@@ -14,35 +14,34 @@ import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
 import net.sourceforge.pmd.lang.rule.properties.MethodProperty;
-import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 import net.sourceforge.pmd.util.ClassUtil;
 
 /**
- *
  * @author Brian Remedios
  */
 public class MethodEditorFactory extends AbstractEditorFactory<Method> {
 
-	public static final MethodEditorFactory instance = new MethodEditorFactory();
-	public static final String[] UnwantedPrefixes = new String[] {
-            "java.lang.reflect.",
-	        "java.lang.",
-	        "java.util."
-	        };
+    public static final MethodEditorFactory instance = new MethodEditorFactory();
+    public static final String[] UnwantedPrefixes = new String[] {
+        "java.lang.reflect.",
+        "java.lang.",
+        "java.util."
+    };
 
-	public static final Method stringLength = ClassUtil.methodFor(String.class, "length", ClassUtil.EMPTY_CLASS_ARRAY);
+    public static final Method stringLength = ClassUtil.methodFor(String.class, "length", ClassUtil.EMPTY_CLASS_ARRAY);
 
-	private MethodEditorFactory() { }
+
+    private MethodEditorFactory() { }
 
 
     public PropertyDescriptor<Method> createDescriptor(String name, String optionalDescription, Control[] otherData) {
-        return new MethodProperty(name, "Method value " + name, stringLength, new String[] { "java.lang" }, 0.0f);
+        return new MethodProperty(name, "Method value " + name, stringLength, new String[] {"java.lang"}, 0.0f);
     }
 
 
     protected Method valueFrom(Control valueControl) {
 
-        return ((MethodPicker)valueControl).getMethod();
+        return ((MethodPicker) valueControl).getMethod();
     }
 
 
@@ -54,17 +53,19 @@ public class MethodEditorFactory extends AbstractEditorFactory<Method> {
 
         fillWidget(picker, desc, source);
 
-        final MethodProperty mp = methodPropertyFrom(desc);
-
         picker.addSelectionListener(new SelectionAdapter() {
             public void widgetSelected(SelectionEvent e) {
                 Method newValue = picker.getMethod();
-                if (newValue == null) return;
+                if (newValue == null) {
+                    return;
+                }
 
-                Method existingValue = valueFor(source, mp);
-                if (existingValue == newValue) return;
+                Method existingValue = valueFor(source, desc);
+                if (existingValue == newValue) {
+                    return;
+                }
 
-                source.setProperty(mp, newValue);
+                source.setProperty(desc, newValue);
                 fillWidget(picker, desc, source);     // redraw
                 listener.changed(source, desc, newValue);
             }
@@ -73,20 +74,11 @@ public class MethodEditorFactory extends AbstractEditorFactory<Method> {
         return picker;
     }
 
-    private static MethodProperty methodPropertyFrom(PropertyDescriptor<?> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-           return (MethodProperty) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
-        } else {
-            return (MethodProperty)desc;
-        }
-    }
-
 
     protected void fillWidget(MethodPicker widget, PropertyDescriptor<Method> desc, PropertySource source) {
 
         Method method = valueFor(source, desc);
         widget.setMethod(method);
         adjustRendering(source, desc, widget);
-	}
+    }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MethodEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MethodEditorFactory.java
@@ -7,7 +7,7 @@ import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
 import net.sourceforge.pmd.lang.rule.properties.MethodProperty;
-import net.sourceforge.pmd.lang.rule.properties.PropertyDescriptorWrapper;
+import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 import net.sourceforge.pmd.util.ClassUtil;
 
 import org.eclipse.swt.SWT;

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiEnumerationEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiEnumerationEditorFactory.java
@@ -1,5 +1,7 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
+import static net.sourceforge.pmd.eclipse.ui.preferences.editors.EnumerationEditorFactory.choices;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -61,7 +63,7 @@ public class MultiEnumerationEditorFactory extends AbstractMultiValueEditorFacto
         EnumeratedPropertyDescriptor<Object, List<Object>> multi
             = (EnumeratedPropertyDescriptor<Object, List<Object>>) desc;
 
-        Object[] choices = multi.choices();
+        Object[] choices = choices(multi);
         List<Object> values = source.getProperty(desc);
 
         return choices.length > values.size();
@@ -77,8 +79,8 @@ public class MultiEnumerationEditorFactory extends AbstractMultiValueEditorFacto
             = (EnumeratedPropertyDescriptor<Object, List<Object>>) desc;
 
         // TODO remove all choices already chosen by previous widgets
-        combo.setItems(SWTUtil.labelsIn(ep.choices(), 0));
-        int selectionIdx = EnumerationEditorFactory.indexOf(value, ep.choices());
+        combo.setItems(SWTUtil.labelsIn(choices(ep), 0));
+        int selectionIdx = EnumerationEditorFactory.indexOf(value, choices(ep));
         if (selectionIdx >= 0) {
             combo.select(selectionIdx);
         }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiEnumerationEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiEnumerationEditorFactory.java
@@ -9,11 +9,10 @@ import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Text;
 
+import net.sourceforge.pmd.EnumeratedPropertyDescriptor;
 import net.sourceforge.pmd.PropertyDescriptor;
 import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-import net.sourceforge.pmd.lang.rule.properties.EnumeratedMultiProperty;
-import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 import net.sourceforge.pmd.util.CollectionUtil;
 
 /**
@@ -59,7 +58,8 @@ public class MultiEnumerationEditorFactory extends AbstractMultiValueEditorFacto
     @Override
     protected boolean canAddNewRowFor(PropertyDescriptor<List<Object>> desc, PropertySource source) {
 
-        EnumeratedMultiProperty<?> multi = enumerationPropertyFrom(desc);
+        EnumeratedPropertyDescriptor<Object, List<Object>> multi
+            = (EnumeratedPropertyDescriptor<Object, List<Object>>) desc;
 
         Object[] choices = multi.choices();
         List<Object> values = source.getProperty(desc);
@@ -68,22 +68,13 @@ public class MultiEnumerationEditorFactory extends AbstractMultiValueEditorFacto
     }
 
 
-    private static EnumeratedMultiProperty<?> enumerationPropertyFrom(PropertyDescriptor<?> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-            return (EnumeratedMultiProperty<?>) ((PropertyDescriptorWrapper<?>) desc).getPropertyDescriptor();
-        } else {
-            return (EnumeratedMultiProperty<?>) desc;
-        }
-    }
-
-
     @Override
     protected Control addWidget(Composite parent, Object value, PropertyDescriptor<List<Object>> desc, final PropertySource source) {
 
         final Combo combo = new Combo(parent, SWT.READ_ONLY);
 
-        final EnumeratedMultiProperty<?> ep = enumerationPropertyFrom(desc);
+        final EnumeratedPropertyDescriptor<Object, List<Object>> ep
+            = (EnumeratedPropertyDescriptor<Object, List<Object>>) desc;
 
         // TODO remove all choices already chosen by previous widgets
         combo.setItems(SWTUtil.labelsIn(ep.choices(), 0));

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiEnumerationEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiEnumerationEditorFactory.java
@@ -1,112 +1,128 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
+import java.util.Collections;
 import java.util.List;
-
-import net.sourceforge.pmd.PropertyDescriptor;
-import net.sourceforge.pmd.PropertySource;
-import net.sourceforge.pmd.Rule;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-import net.sourceforge.pmd.lang.rule.properties.EnumeratedMultiProperty;
-import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
-import net.sourceforge.pmd.util.CollectionUtil;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Text;
+
+import net.sourceforge.pmd.PropertyDescriptor;
+import net.sourceforge.pmd.PropertySource;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
+import net.sourceforge.pmd.lang.rule.properties.EnumeratedMultiProperty;
+import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
+import net.sourceforge.pmd.util.CollectionUtil;
+
 /**
- * Behaviour:
- *           Provide a set of widgets that allows the user to select any number of items from a fixed set of choices. Each item can only appear once.
+ * Behaviour: Provide a set of widgets that allows the user to select any number of items from a fixed set of choices.
+ * Each item can only appear once.
  *
- * Provide a combo box for each value selected while ensuring that their choices only contain unselected values. If the last combo box holds the only
- * remaining choice then ensure it gets disabled, the user can only delete it or the previous ones. If the user deletes a previous one then re-enable
- * the last one and add the deleted value to its set of choices.
+ * Provide a combo box for each value selected while ensuring that their choices only contain unselected values. If the
+ * last combo box holds the only remaining choice then ensure it gets disabled, the user can only delete it or the
+ * previous ones. If the user deletes a previous one then re-enable the last one and add the deleted value to its set of
+ * choices.
  *
  * @author Brian Remedios
  *
- *  ! PLACEHOLDER ONLY - NOT FINISHED YET !
+ *         ! PLACEHOLDER ONLY - NOT FINISHED YET !
  */
-public class MultiEnumerationEditorFactory extends AbstractMultiValueEditorFactory {
+public class MultiEnumerationEditorFactory extends AbstractMultiValueEditorFactory<Object> {
 
     public static final MultiEnumerationEditorFactory instance = new MultiEnumerationEditorFactory();
 
-	private MultiEnumerationEditorFactory() { }
+
+    private MultiEnumerationEditorFactory() { }
+
+
+    @Override
+    protected Object addValueIn(Control widget, PropertyDescriptor<List<Object>> desc, PropertySource source) {
+
+        int idx = ((Combo) widget).getSelectionIndex();
+        if (idx < 0) {
+            return null;
+        }
+
+        String newValue = ((Combo) widget).getItem(idx);
+
+        List<Object> currentValues = valueFor(source, desc);
+        int nAdded = CollectionUtil.addWithoutDuplicates(Collections.singleton((Object) newValue), currentValues);
+        return nAdded == 0 ? null : newValue;
+    }
+
+
+    /**
+     * Only add a new widget row if there are any remaining choices to make
+     */
+    @Override
+    protected boolean canAddNewRowFor(PropertyDescriptor<List<Object>> desc, PropertySource source) {
+
+        EnumeratedMultiProperty<?> multi = enumerationPropertyFrom(desc);
+
+        Object[] choices = multi.choices();
+        List<Object> values = source.getProperty(desc);
+
+        return choices.length > values.size();
+    }
+
 
     private static EnumeratedMultiProperty<?> enumerationPropertyFrom(PropertyDescriptor<?> desc) {
 
         if (desc instanceof PropertyDescriptorWrapper<?>) {
-           return (EnumeratedMultiProperty<?>) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
+            return (EnumeratedMultiProperty<?>) ((PropertyDescriptorWrapper<?>) desc).getPropertyDescriptor();
         } else {
-            return (EnumeratedMultiProperty<?>)desc;
+            return (EnumeratedMultiProperty<?>) desc;
         }
     }
 
-	@Override
-	protected Object addValueIn(Control widget, PropertyDescriptor<?> desc, PropertySource source) {
 
-		int idx = ((Combo)widget).getSelectionIndex();
-		if (idx < 0) return null;
-
-		String newValue = ((Combo)widget).getItem(idx);
-
-	    String[] currentValues = (String[])valueFor(source, desc);
-	    String[] newValues = CollectionUtil.addWithoutDuplicates(currentValues, newValue);
-	    if (currentValues.length == newValues.length) return null;
-
-	    source.setProperty((EnumeratedMultiProperty<?>)desc, newValues);
-	    return newValue;
-	}
-
-	/**
-	 * Only add a new widget row if there are any remaining choices to make
-	 */
-	@Override
-    protected boolean canAddNewRowFor(PropertyDescriptor<?> desc, PropertySource source) {
-
-    	Object[] choices = desc.choices();
-		Object[] values = (Object[])source.getProperty(desc);
-
-		return choices.length > values.length;
-    }
-
-	@Override
-	protected Control addWidget(Composite parent, Object value, PropertyDescriptor<?> desc, final PropertySource source) {
+    @Override
+    protected Control addWidget(Composite parent, Object value, PropertyDescriptor<List<Object>> desc, final PropertySource source) {
 
         final Combo combo = new Combo(parent, SWT.READ_ONLY);
 
         final EnumeratedMultiProperty<?> ep = enumerationPropertyFrom(desc);
 
-  // TODO remove all choices already chosen by previous widgets
+        // TODO remove all choices already chosen by previous widgets
         combo.setItems(SWTUtil.labelsIn(ep.choices(), 0));
         int selectionIdx = EnumerationEditorFactory.indexOf(value, ep.choices());
-        if (selectionIdx >= 0) combo.select(selectionIdx);
-        
+        if (selectionIdx >= 0) {
+            combo.select(selectionIdx);
+        }
+
         return combo;
-	}
+    }
 
-	@Override
-	protected void setValue(Control widget, Object value) {
-		// not necessary, set in addWidget method?
-	}
 
-	@Override
-	protected void update(PropertySource source, PropertyDescriptor<?> desc, List<Object> newValues) {
-		source.setProperty((EnumeratedMultiProperty<?>)desc, newValues.toArray(new String[newValues.size()]));
-	}
+    @Override
+    protected void setValue(Control widget, Object value) {
+        // not necessary, set in addWidget method?
+    }
 
-	@Override
-	protected Object valueFrom(Control valueControl) {			// unreferenced method?
-		return null;
-	}
 
-	public PropertyDescriptor<?> createDescriptor(String name, String description, Control[] otherData) {
-		return null;
-	}
+    @Override
+    protected void update(PropertySource source, PropertyDescriptor<List<Object>> desc, List<Object> newValues) {
+        source.setProperty(desc, newValues);
+    }
 
-	@Override
-	protected void configure(Text text, PropertyDescriptor<?> desc, PropertySource source, ValueChangeListener listener) {
-		text.setEditable(false);
-	}
+
+    @Override
+    protected List<Object> valueFrom(Control valueControl) {            // unreferenced method?
+        return null;
+    }
+
+
+    public PropertyDescriptor<List<Object>> createDescriptor(String name, String description, Control[] otherData) {
+        return null;
+    }
+
+
+    @Override
+    protected void configure(Text text, PropertyDescriptor<List<Object>> desc, PropertySource source, ValueChangeListener listener) {
+        text.setEditable(false);
+    }
+
 
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiEnumerationEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiEnumerationEditorFactory.java
@@ -7,7 +7,7 @@ import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
 import net.sourceforge.pmd.lang.rule.properties.EnumeratedMultiProperty;
-import net.sourceforge.pmd.lang.rule.properties.PropertyDescriptorWrapper;
+import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 import net.sourceforge.pmd.util.CollectionUtil;
 
 import org.eclipse.swt.SWT;

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiIntegerEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiIntegerEditorFactory.java
@@ -74,7 +74,7 @@ public class MultiIntegerEditorFactory extends AbstractMultiValueEditorFactory<I
     }
 
 
-    protected Control addWidget(Composite parent, Object value, PropertyDescriptor<List<Integer>> desc,
+    protected Control addWidget(Composite parent, Integer value, PropertyDescriptor<List<Integer>> desc,
                                 PropertySource source) {
 
         NumericPropertyDescriptor<List<Integer>> ip = numericPropertyFrom(desc);   // TODO - do I really have to do this?
@@ -92,22 +92,22 @@ public class MultiIntegerEditorFactory extends AbstractMultiValueEditorFactory<I
     }
 
 
-    protected void setValue(Control widget, Object valueIn) {
-
+    protected void setValue(Control widget, Integer valueIn) {
         Spinner spinner = (Spinner) widget;
-        int value = valueIn == null ? spinner.getMinimum() : ((Number) valueIn).intValue();
+        int value = valueIn == null ? spinner.getMinimum() : valueIn;
         spinner.setSelection(value);
     }
 
 
-    protected void configure(final Text textWidget, final PropertyDescriptor<?> desc, final PropertySource source, final ValueChangeListener listener) {
+    protected void configure(final Text textWidget, final PropertyDescriptor<List<Integer>> desc,
+                             final PropertySource source, final ValueChangeListener listener) {
 
         final IntegerMultiProperty imp = (IntegerMultiProperty) numericPropertyFrom(desc);
 
         textWidget.addListener(SWT.FocusOut, new Listener() {
             public void handleEvent(Event event) {
-                Integer[] newValue = currentIntegers(textWidget);
-                Integer[] existingValue = (Integer[]) valueFor(source, imp);
+                List<Integer> newValue = currentIntegers(textWidget);
+                List<Integer> existingValue = valueFor(source, imp);
                 if (CollectionUtil.areSemanticEquals(existingValue, newValue)) {
                     return;
                 }
@@ -120,23 +120,18 @@ public class MultiIntegerEditorFactory extends AbstractMultiValueEditorFactory<I
     }
 
 
-    protected void update(PropertySource source, PropertyDescriptor<?> desc, List<Object> newValues) {
-        source.setProperty((IntegerMultiProperty) desc, newValues.toArray(new Integer[newValues.size()]));
+    protected void update(PropertySource source, PropertyDescriptor<List<Integer>> desc, List<Integer> newValues) {
+        source.setProperty(desc, newValues);
     }
 
 
     @Override
-    protected Object addValueIn(Control widget, PropertyDescriptor<?> desc, PropertySource source) {
+    protected Integer addValueIn(Control widget, PropertyDescriptor<List<Integer>> desc, PropertySource source) {
 
-        Integer newValue = Integer.valueOf(((Spinner) widget).getSelection());
+        Integer newValue = ((Spinner) widget).getSelection();
 
-        Integer[] currentValues = (Integer[]) valueFor(source, desc);
-        Integer[] newValues = CollectionUtil.addWithoutDuplicates(currentValues, newValue);
-        if (currentValues.length == newValues.length) {
-            return null;
-        }
-
-        source.setProperty((IntegerMultiProperty) desc, newValues);
-        return newValue;
+        List<Integer> currentValues = valueFor(source, desc);
+        int nAdded = CollectionUtil.addWithoutDuplicates(Collections.singleton(newValue), currentValues);
+        return nAdded == 0 ? null : newValue;
     }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiIntegerEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiIntegerEditorFactory.java
@@ -1,16 +1,8 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-
-import net.sourceforge.pmd.NumericPropertyDescriptor;
-import net.sourceforge.pmd.PropertyDescriptor;
-import net.sourceforge.pmd.PropertySource;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-import net.sourceforge.pmd.lang.rule.properties.IntegerMultiProperty;
-import net.sourceforge.pmd.lang.rule.properties.PropertyDescriptorWrapper;
-import net.sourceforge.pmd.util.CollectionUtil;
-import net.sourceforge.pmd.util.NumericConstants;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
@@ -19,83 +11,106 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Spinner;
 import org.eclipse.swt.widgets.Text;
+
+import net.sourceforge.pmd.NumericPropertyDescriptor;
+import net.sourceforge.pmd.PropertyDescriptor;
+import net.sourceforge.pmd.PropertySource;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
+import net.sourceforge.pmd.lang.rule.properties.IntegerMultiProperty;
+import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
+import net.sourceforge.pmd.util.CollectionUtil;
+import net.sourceforge.pmd.util.NumericConstants;
+
 /**
- * Behaviour:
- *           Provide a set of widgets that allows the user to pick a range of integer values. The selected values can only exist once.
+ * Behaviour: Provide a set of widgets that allows the user to pick a range of integer values. The selected values can
+ * only exist once.
  *
- * Provide a spin box for each value selected while ensuring that their choices only contain unselected values. If the last spin box holds the only
- * remaining choice then ensure it gets disabled, the user can only delete it or the previous ones. If the user deletes a previous one then re-enable
- * the last one and add the deleted value to its set of choices.
+ * Provide a spin box for each value selected while ensuring that their choices only contain unselected values. If the
+ * last spin box holds the only remaining choice then ensure it gets disabled, the user can only delete it or the
+ * previous ones. If the user deletes a previous one then re-enable the last one and add the deleted value to its set of
+ * choices.
  *
  * @author Brian Remedios
  */
-public class MultiIntegerEditorFactory extends AbstractMultiValueEditorFactory {
+public class MultiIntegerEditorFactory extends AbstractMultiValueEditorFactory<Integer> {
 
     public static final MultiIntegerEditorFactory instance = new MultiIntegerEditorFactory();
 
-    private static final Integer[] emptyIntSet = new Integer[0];
 
-    private MultiIntegerEditorFactory() {   }
+    private MultiIntegerEditorFactory() { }
 
-    public PropertyDescriptor<?> createDescriptor(String name, String optionalDescription, Control[] otherData) {
-        return new IntegerMultiProperty(name, "Integer values " + name, NumericConstants.ZERO, Integer.valueOf(10), new Integer[] {NumericConstants.ZERO}, 0.0f);
+
+    public PropertyDescriptor<List<Integer>> createDescriptor(String name, String optionalDescription,
+                                                              Control[] otherData) {
+
+        return new IntegerMultiProperty(name, "Integer values "
+            + name, NumericConstants.ZERO, 10, new Integer[] {NumericConstants.ZERO}, 0.0f);
     }
 
-    protected Object valueFrom(Control valueControl) {
 
-        return currentIntegers((Text)valueControl);
+    protected List<Integer> valueFrom(Control valueControl) {
+        return currentIntegers((Text) valueControl);
     }
 
-    private Integer[] currentIntegers(Text textWidget) {
 
-        String[] numberStrings = textWidgetValues(textWidget);
-        if (numberStrings.length == 0) return emptyIntSet;
+    private List<Integer> currentIntegers(Text textWidget) {
 
-        List<Integer> ints = new ArrayList<Integer>(numberStrings.length);
+        List<String> numberStrings = textWidgetValues(textWidget);
+        if (numberStrings.isEmpty()) {
+            return Collections.emptyList();
+        }
 
+        List<Integer> ints = new ArrayList<Integer>(numberStrings.size());
 
         for (String numString : numberStrings) {
             try {
-                Integer intrg = Integer.parseInt(numString);
-                ints.add(intrg);
+                Integer integer = Integer.parseInt(numString);
+                ints.add(integer);
             } catch (Exception e) {
-               // just eat it for now
+                // just eat it for now
             }
         }
-        return ints.toArray(new Integer[ints.size()]);
+        return ints;
     }
 
-    private static NumericPropertyDescriptor<?> numericPropertyFrom(PropertyDescriptor<?> desc) {
 
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-           return (NumericPropertyDescriptor<?>) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
-        } else {
-            return (NumericPropertyDescriptor<?>)desc;
-        }
-    }
+    protected Control addWidget(Composite parent, Object value, PropertyDescriptor<List<Integer>> desc,
+                                PropertySource source) {
 
-    protected Control addWidget(Composite parent, Object value, PropertyDescriptor<?> desc, PropertySource source) {
-
-        NumericPropertyDescriptor<?> ip = numericPropertyFrom(desc);   // TODO - do I really have to do this?
+        NumericPropertyDescriptor<List<Integer>> ip = numericPropertyFrom(desc);   // TODO - do I really have to do this?
         return IntegerEditorFactory.newSpinner(parent, ip, value);
     }
 
+
+    private static NumericPropertyDescriptor<List<Integer>> numericPropertyFrom(PropertyDescriptor<List<Integer>> desc) {
+
+        if (desc instanceof PropertyDescriptorWrapper<?>) {
+            return (NumericPropertyDescriptor<List<Integer>>) ((PropertyDescriptorWrapper<List<Integer>>) desc).getPropertyDescriptor();
+        } else {
+            return (NumericPropertyDescriptor<List<Integer>>) desc;
+        }
+    }
+
+
     protected void setValue(Control widget, Object valueIn) {
 
-        Spinner spinner = (Spinner)widget;
-        int value = valueIn == null ? spinner.getMinimum() : ((Number)valueIn).intValue();
+        Spinner spinner = (Spinner) widget;
+        int value = valueIn == null ? spinner.getMinimum() : ((Number) valueIn).intValue();
         spinner.setSelection(value);
     }
 
+
     protected void configure(final Text textWidget, final PropertyDescriptor<?> desc, final PropertySource source, final ValueChangeListener listener) {
 
-        final IntegerMultiProperty imp = (IntegerMultiProperty)numericPropertyFrom(desc);
+        final IntegerMultiProperty imp = (IntegerMultiProperty) numericPropertyFrom(desc);
 
         textWidget.addListener(SWT.FocusOut, new Listener() {
             public void handleEvent(Event event) {
                 Integer[] newValue = currentIntegers(textWidget);
-                Integer[] existingValue = (Integer[])valueFor(source, imp);
-                if (CollectionUtil.areSemanticEquals(existingValue, newValue)) return;
+                Integer[] existingValue = (Integer[]) valueFor(source, imp);
+                if (CollectionUtil.areSemanticEquals(existingValue, newValue)) {
+                    return;
+                }
 
                 source.setProperty(imp, newValue);
                 fillWidget(textWidget, desc, source);   // display the accepted values
@@ -104,20 +119,24 @@ public class MultiIntegerEditorFactory extends AbstractMultiValueEditorFactory {
         });
     }
 
+
     protected void update(PropertySource source, PropertyDescriptor<?> desc, List<Object> newValues) {
-        source.setProperty((IntegerMultiProperty)desc, newValues.toArray(new Integer[newValues.size()]));
+        source.setProperty((IntegerMultiProperty) desc, newValues.toArray(new Integer[newValues.size()]));
     }
+
 
     @Override
     protected Object addValueIn(Control widget, PropertyDescriptor<?> desc, PropertySource source) {
 
-        Integer newValue= Integer.valueOf(((Spinner)widget).getSelection());
+        Integer newValue = Integer.valueOf(((Spinner) widget).getSelection());
 
-        Integer[] currentValues = (Integer[])valueFor(source, desc);
+        Integer[] currentValues = (Integer[]) valueFor(source, desc);
         Integer[] newValues = CollectionUtil.addWithoutDuplicates(currentValues, newValue);
-        if (currentValues.length == newValues.length) return null;
+        if (currentValues.length == newValues.length) {
+            return null;
+        }
 
-        source.setProperty((IntegerMultiProperty)desc, newValues);
+        source.setProperty((IntegerMultiProperty) desc, newValues);
         return newValue;
     }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiIntegerEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiIntegerEditorFactory.java
@@ -93,7 +93,7 @@ public class MultiIntegerEditorFactory extends AbstractMultiValueEditorFactory<I
             public void handleEvent(Event event) {
                 List<Integer> newValue = currentIntegers(textWidget);
                 List<Integer> existingValue = valueFor(source, desc);
-                if (CollectionUtil.areSemanticEquals(existingValue, newValue)) {
+                if (existingValue != null && existingValue.equals(newValue)) {
                     return;
                 }
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiIntegerEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiIntegerEditorFactory.java
@@ -17,7 +17,6 @@ import net.sourceforge.pmd.PropertyDescriptor;
 import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
 import net.sourceforge.pmd.lang.rule.properties.IntegerMultiProperty;
-import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 import net.sourceforge.pmd.util.CollectionUtil;
 import net.sourceforge.pmd.util.NumericConstants;
 
@@ -76,19 +75,7 @@ public class MultiIntegerEditorFactory extends AbstractMultiValueEditorFactory<I
 
     protected Control addWidget(Composite parent, Integer value, PropertyDescriptor<List<Integer>> desc,
                                 PropertySource source) {
-
-        NumericPropertyDescriptor<List<Integer>> ip = numericPropertyFrom(desc);   // TODO - do I really have to do this?
-        return IntegerEditorFactory.newSpinner(parent, ip, value);
-    }
-
-
-    private static NumericPropertyDescriptor<List<Integer>> numericPropertyFrom(PropertyDescriptor<List<Integer>> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-            return (NumericPropertyDescriptor<List<Integer>>) ((PropertyDescriptorWrapper<List<Integer>>) desc).getPropertyDescriptor();
-        } else {
-            return (NumericPropertyDescriptor<List<Integer>>) desc;
-        }
+        return IntegerEditorFactory.newSpinner(parent, (NumericPropertyDescriptor<List<Integer>>) desc, value);
     }
 
 
@@ -102,17 +89,15 @@ public class MultiIntegerEditorFactory extends AbstractMultiValueEditorFactory<I
     protected void configure(final Text textWidget, final PropertyDescriptor<List<Integer>> desc,
                              final PropertySource source, final ValueChangeListener listener) {
 
-        final IntegerMultiProperty imp = (IntegerMultiProperty) numericPropertyFrom(desc);
-
         textWidget.addListener(SWT.FocusOut, new Listener() {
             public void handleEvent(Event event) {
                 List<Integer> newValue = currentIntegers(textWidget);
-                List<Integer> existingValue = valueFor(source, imp);
+                List<Integer> existingValue = valueFor(source, desc);
                 if (CollectionUtil.areSemanticEquals(existingValue, newValue)) {
                     return;
                 }
 
-                source.setProperty(imp, newValue);
+                source.setProperty(desc, newValue);
                 fillWidget(textWidget, desc, source);   // display the accepted values
                 listener.changed(source, desc, newValue);
             }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiMethodEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiMethodEditorFactory.java
@@ -29,7 +29,7 @@ public class MultiMethodEditorFactory extends AbstractMultiValueEditorFactory {
 
 	private MultiMethodEditorFactory() { }
 
-    public PropertyDescriptor<?> createDescriptor(String name, String optionalDescription, Control[] otherData) {
+    public PropertyDescriptor<List<Method>> createDescriptor(String name, String optionalDescription, Control[] otherData) {
         return new MethodMultiProperty(name, "Method value " + name, new Method[] {MethodEditorFactory.stringLength}, new String[] { "java.lang" }, 0.0f);
     }
 
@@ -105,8 +105,8 @@ public class MultiMethodEditorFactory extends AbstractMultiValueEditorFactory {
         textWidget.setEditable(false);
     }
 
-    protected void update(PropertySource source, PropertyDescriptor<?> desc, List<Object> newValues) {
-    	source.setProperty((MethodMultiProperty)desc, newValues.toArray(new Method[newValues.size()]));
+    protected void update(PropertySource source, PropertyDescriptor<?> desc, List<Method> newValues) {
+    	source.setProperty((MethodMultiProperty)desc, newValues);
     }
 
     @Override

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiMethodEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiMethodEditorFactory.java
@@ -1,10 +1,16 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Text;
 
 import net.sourceforge.pmd.PropertyDescriptor;
 import net.sourceforge.pmd.PropertySource;
@@ -14,116 +20,129 @@ import net.sourceforge.pmd.lang.rule.properties.MethodMultiProperty;
 import net.sourceforge.pmd.util.ClassUtil;
 import net.sourceforge.pmd.util.CollectionUtil;
 
-import org.eclipse.swt.SWT;
-import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Control;
-import org.eclipse.swt.widgets.Text;
-
 /**
- *
  * @author Brian Remedios
  */
-public class MultiMethodEditorFactory extends AbstractMultiValueEditorFactory {
+public class MultiMethodEditorFactory extends AbstractMultiValueEditorFactory<Method> {
 
-	public static final MultiMethodEditorFactory instance = new MultiMethodEditorFactory();
+    public static final MultiMethodEditorFactory instance = new MultiMethodEditorFactory();
 
-	private MultiMethodEditorFactory() { }
+
+    private MultiMethodEditorFactory() { }
+
 
     public PropertyDescriptor<List<Method>> createDescriptor(String name, String optionalDescription, Control[] otherData) {
-        return new MethodMultiProperty(name, "Method value " + name, new Method[] {MethodEditorFactory.stringLength}, new String[] { "java.lang" }, 0.0f);
+        return new MethodMultiProperty(name, "Method value "
+            + name, new Method[] {MethodEditorFactory.stringLength}, new String[] {"java.lang"}, 0.0f);
     }
 
-	public static String[] signaturesFor(Method[] methods) {
-	    String[] typeNames = new String[methods.length];
-        for (int i=0; i<typeNames.length; i++) {
-            typeNames[i] = Util.signatureFor(methods[i], MethodEditorFactory.UnwantedPrefixes);
-        }
-        return typeNames;
-	}
 
-	private static String asString(Map<String, List<Method>> methodGroups) {
+    protected void fillWidget(Text textWidget, PropertyDescriptor<List<Method>> desc, PropertySource source) {
 
-	    if (methodGroups.isEmpty()) return "";
-
-	    StringBuilder sb = new StringBuilder();
-	    Iterator<Entry<String, List<Method>>> iter = methodGroups.entrySet().iterator();
-	    Entry<String, List<Method>> entry = iter.next();
-
-	    sb.append(entry.getKey()).append('[');
-	    allSignaturesOn(sb, entry.getValue(), ",");
-	    sb.append(']');
-
-	    while (iter.hasNext()) {
-	        entry = iter.next();
-	        sb.append("  ").append(entry.getKey()).append('[');
-	        allSignaturesOn(sb, entry.getValue(), ", ");
-	        sb.append(']');
-	    }
-
-	    return sb.toString();
-	}
-
-	private static void allSignaturesOn(StringBuilder sb, List<Method> methods, String delimiter) {
-
-	    sb.append(
-	        Util.signatureFor(methods.get(0), MethodEditorFactory.UnwantedPrefixes)
-	        );
-
-	    for (int i=1; i<methods.size(); i++) {
-	        sb.append(delimiter).append(
-	            Util.signatureFor(methods.get(i), MethodEditorFactory.UnwantedPrefixes)
-	            );
-	    }
-	}
-
-    protected void fillWidget(Text textWidget, PropertyDescriptor<?> desc, PropertySource source) {
-
-        Method[] values = (Method[])valueFor(source, desc);
+        List<Method> values = valueFor(source, desc);
         if (values == null) {
             textWidget.setText("");
             return;
         }
 
         Map<String, List<Method>> methodMap = ClassUtil.asMethodGroupsByTypeName(values);
-        textWidget.setText(values == null ? "" : asString(methodMap));
+        textWidget.setText(asString(methodMap));
 
         adjustRendering(source, desc, textWidget);
     }
 
-    protected Control addWidget(Composite parent, Object value, PropertyDescriptor<?> desc, PropertySource source) {
+
+    private static String asString(Map<String, List<Method>> methodGroups) {
+
+        if (methodGroups.isEmpty()) {
+            return "";
+        }
+
+        StringBuilder sb = new StringBuilder();
+        Iterator<Entry<String, List<Method>>> iter = methodGroups.entrySet().iterator();
+        Entry<String, List<Method>> entry = iter.next();
+
+        sb.append(entry.getKey()).append('[');
+        allSignaturesOn(sb, entry.getValue(), ",");
+        sb.append(']');
+
+        while (iter.hasNext()) {
+            entry = iter.next();
+            sb.append("  ").append(entry.getKey()).append('[');
+            allSignaturesOn(sb, entry.getValue(), ", ");
+            sb.append(']');
+        }
+
+        return sb.toString();
+    }
+
+
+    private static void allSignaturesOn(StringBuilder sb, List<Method> methods, String delimiter) {
+
+        sb.append(
+            Util.signatureFor(methods.get(0), MethodEditorFactory.UnwantedPrefixes)
+        );
+
+        for (int i = 1; i < methods.size(); i++) {
+            sb.append(delimiter).append(
+                Util.signatureFor(methods.get(i), MethodEditorFactory.UnwantedPrefixes)
+            );
+        }
+    }
+
+
+    @Override
+    protected Control addWidget(Composite parent, Method value, PropertyDescriptor<List<Method>> desc,
+                                PropertySource source) {
         MethodPicker widget = new MethodPicker(parent, SWT.SINGLE | SWT.BORDER, MethodEditorFactory.UnwantedPrefixes);
         setValue(widget, value);
         return widget;
     }
 
-    protected void setValue(Control widget, Object value) {
-        Method method = value == null ? null : (Method)value;
-        ((MethodPicker)widget).setMethod(method);
+
+    @Override
+    protected void setValue(Control widget, Method value) {
+        ((MethodPicker) widget).setMethod(value);
     }
 
-    protected void configure(final Text textWidget, final PropertyDescriptor<?> desc, final PropertySource source, final ValueChangeListener listener) {
+
+    @Override
+    protected void configure(final Text textWidget, final PropertyDescriptor<List<Method>> desc,
+                             final PropertySource source, final ValueChangeListener listener) {
         textWidget.setEditable(false);
     }
 
-    protected void update(PropertySource source, PropertyDescriptor<?> desc, List<Method> newValues) {
-    	source.setProperty((MethodMultiProperty)desc, newValues);
-    }
 
     @Override
-    protected Object addValueIn(Control widget, PropertyDescriptor<?> desc, PropertySource source) {
-
-        Method newValue = ((MethodPicker)widget).getMethod();
-        if (newValue == null) return null;
-
-        Method[] currentValues = (Method[])valueFor(source, desc);
-        Method[] newValues = CollectionUtil.addWithoutDuplicates(currentValues, newValue);
-        if (currentValues.length == newValues.length) return null;  // nothing changed
-
-        source.setProperty((MethodMultiProperty)desc, newValues);
-        return newValue;
+    protected void update(PropertySource source, PropertyDescriptor<List<Method>> desc, List<Method> newValues) {
+        source.setProperty(desc, newValues);
     }
 
-    protected Object valueFrom(Control valueControl) {	// not necessary for this type
+
+    @Override
+    protected Method addValueIn(Control widget, PropertyDescriptor<List<Method>> desc, PropertySource source) {
+
+        Method newValue = ((MethodPicker) widget).getMethod();
+        if (newValue == null) {
+            return null;
+        }
+
+        List<Method> currentValues = valueFor(source, desc);
+        int nAdded = CollectionUtil.addWithoutDuplicates(Collections.singleton(newValue), currentValues);
+        return nAdded == 0 ? null : newValue;
+    }
+
+
+    protected List<Method> valueFrom(Control valueControl) {    // not necessary for this type
         return null;
+    }
+
+
+    public static String[] signaturesFor(Method[] methods) {
+        String[] typeNames = new String[methods.length];
+        for (int i = 0; i < typeNames.length; i++) {
+            typeNames[i] = Util.signatureFor(methods[i], MethodEditorFactory.UnwantedPrefixes);
+        }
+        return typeNames;
     }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiStringEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiStringEditorFactory.java
@@ -59,7 +59,7 @@ public class MultiStringEditorFactory extends AbstractMultiValueEditorFactory<St
             public void handleEvent(Event event) {
                 List<String> newValues = textWidgetValues(textWidget);
                 List<String> existingValues = valueFor(source, desc);
-                if (CollectionUtil.areSemanticEquals(existingValues, newValues)) {
+                if (existingValues != null && existingValues.equals(newValues)) {
                     return;
                 }
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiStringEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiStringEditorFactory.java
@@ -37,7 +37,8 @@ public class MultiStringEditorFactory extends AbstractMultiValueEditorFactory<St
     }
 
 
-    protected Control addWidget(Composite parent, Object value, PropertyDescriptor<List<String>> desc,
+    @Override
+    protected Control addWidget(Composite parent, String value, PropertyDescriptor<List<String>> desc,
                                 PropertySource source) {
         Text textWidget = new Text(parent, SWT.SINGLE | SWT.BORDER);
         setValue(textWidget, value);
@@ -45,8 +46,9 @@ public class MultiStringEditorFactory extends AbstractMultiValueEditorFactory<St
     }
 
 
-    protected void setValue(Control widget, Object value) {
-        ((Text) widget).setText(value == null ? "" : value.toString());
+    @Override
+    protected void setValue(Control widget, String value) {
+        ((Text) widget).setText(value == null ? "" : value);
     }
 
 
@@ -104,7 +106,7 @@ public class MultiStringEditorFactory extends AbstractMultiValueEditorFactory<St
     }
 
 
-    protected Object valueFrom(Control valueControl) {    // not necessary for this type
+    protected List<String> valueFrom(Control valueControl) {    // not necessary for this type
         return null;
     }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiStringEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiStringEditorFactory.java
@@ -14,7 +14,6 @@ import net.sourceforge.pmd.PropertyDescriptor;
 import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
 import net.sourceforge.pmd.lang.rule.properties.StringMultiProperty;
-import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 import net.sourceforge.pmd.util.CollectionUtil;
 import net.sourceforge.pmd.util.StringUtil;
 
@@ -55,17 +54,16 @@ public class MultiStringEditorFactory extends AbstractMultiValueEditorFactory<St
     protected void configure(final Text textWidget, final PropertyDescriptor<List<String>> desc,
                              final PropertySource source, final ValueChangeListener listener) {
 
-        final StringMultiProperty smp = multiStringPropertyFrom(desc);
 
         Listener widgetListener = new Listener() {
             public void handleEvent(Event event) {
                 List<String> newValues = textWidgetValues(textWidget);
-                List<String> existingValues = valueFor(source, smp);
+                List<String> existingValues = valueFor(source, desc);
                 if (CollectionUtil.areSemanticEquals(existingValues, newValues)) {
                     return;
                 }
 
-                source.setProperty(smp, newValues);
+                source.setProperty(desc, newValues);
                 fillWidget(textWidget, desc, source);    // reload with latest scrubbed values
                 listener.changed(source, desc, newValues);
             }
@@ -73,16 +71,6 @@ public class MultiStringEditorFactory extends AbstractMultiValueEditorFactory<St
 
         textWidget.addListener(SWT.FocusOut, widgetListener);
         // textWidget.addListener(SWT.DefaultSelection, widgetListener);
-    }
-
-
-    private static StringMultiProperty multiStringPropertyFrom(PropertyDescriptor<List<String>> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-            return (StringMultiProperty) ((PropertyDescriptorWrapper<?>) desc).getPropertyDescriptor();
-        } else {
-            return (StringMultiProperty) desc;
-        }
     }
 
 
@@ -109,4 +97,6 @@ public class MultiStringEditorFactory extends AbstractMultiValueEditorFactory<St
     protected List<String> valueFrom(Control valueControl) {    // not necessary for this type
         return null;
     }
+
+
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiStringEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiStringEditorFactory.java
@@ -1,14 +1,7 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
+import java.util.Collections;
 import java.util.List;
-
-import net.sourceforge.pmd.PropertyDescriptor;
-import net.sourceforge.pmd.PropertySource;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-import net.sourceforge.pmd.lang.rule.properties.PropertyDescriptorWrapper;
-import net.sourceforge.pmd.lang.rule.properties.StringMultiProperty;
-import net.sourceforge.pmd.util.CollectionUtil;
-import net.sourceforge.pmd.util.StringUtil;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
@@ -17,79 +10,101 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
 
+import net.sourceforge.pmd.PropertyDescriptor;
+import net.sourceforge.pmd.PropertySource;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
+import net.sourceforge.pmd.lang.rule.properties.StringMultiProperty;
+import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
+import net.sourceforge.pmd.util.CollectionUtil;
+import net.sourceforge.pmd.util.StringUtil;
+
 /**
- *
  * @author Brian Remedios
  */
-public class MultiStringEditorFactory extends AbstractMultiValueEditorFactory {
+public class MultiStringEditorFactory extends AbstractMultiValueEditorFactory<String> {
 
     public static final MultiStringEditorFactory instance = new MultiStringEditorFactory();
 
-	private MultiStringEditorFactory() { }
 
-    public PropertyDescriptor<?> createDescriptor(String name, String optionalDescription, Control[] otherData) {
-        return new StringMultiProperty(name, "String value " + name, new String[] {""}, 0.0f, StringMultiProperty.DEFAULT_DELIMITER);
+    private MultiStringEditorFactory() { }
+
+
+    public PropertyDescriptor<List<String>> createDescriptor(String name, String optionalDescription,
+                                                             Control[] otherData) {
+
+        return new StringMultiProperty(name, "String value "
+            + name, new String[] {""}, 0.0f, StringMultiProperty.DEFAULT_DELIMITER);
     }
 
-    private static StringMultiProperty multiStringPropertyFrom(PropertyDescriptor<?> desc) {
 
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-           return (StringMultiProperty) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
-        } else {
-            return (StringMultiProperty)desc;
-        }
-    }
-
-    protected Control addWidget(Composite parent, Object value, PropertyDescriptor<?> desc, PropertySource source) {
+    protected Control addWidget(Composite parent, Object value, PropertyDescriptor<List<String>> desc,
+                                PropertySource source) {
         Text textWidget = new Text(parent, SWT.SINGLE | SWT.BORDER);
-        setValue(textWidget,value);
+        setValue(textWidget, value);
         return textWidget;
     }
 
+
     protected void setValue(Control widget, Object value) {
-        ((Text)widget).setText(value == null ? "" : value.toString());
+        ((Text) widget).setText(value == null ? "" : value.toString());
     }
 
-    protected void configure(final Text textWidget, final PropertyDescriptor<?> desc, final PropertySource source, final ValueChangeListener listener) {
+
+    protected void configure(final Text textWidget, final PropertyDescriptor<List<String>> desc,
+                             final PropertySource source, final ValueChangeListener listener) {
 
         final StringMultiProperty smp = multiStringPropertyFrom(desc);
 
         Listener widgetListener = new Listener() {
-        	public void handleEvent(Event event) {
-        		String[] newValues = textWidgetValues(textWidget);
-        		String[] existingValues = (String[])valueFor(source, smp);
-        		if (CollectionUtil.areSemanticEquals(existingValues, newValues)) return;
+            public void handleEvent(Event event) {
+                List<String> newValues = textWidgetValues(textWidget);
+                List<String> existingValues = valueFor(source, smp);
+                if (CollectionUtil.areSemanticEquals(existingValues, newValues)) {
+                    return;
+                }
 
-        		source.setProperty(smp, newValues);
-        		fillWidget(textWidget, desc, source);    // reload with latest scrubbed values
-        		listener.changed(source, desc, newValues);
-        		}
-        	};
+                source.setProperty(smp, newValues);
+                fillWidget(textWidget, desc, source);    // reload with latest scrubbed values
+                listener.changed(source, desc, newValues);
+            }
+        };
 
         textWidget.addListener(SWT.FocusOut, widgetListener);
-//        textWidget.addListener(SWT.DefaultSelection, widgetListener);
+        // textWidget.addListener(SWT.DefaultSelection, widgetListener);
     }
+
+
+    private static StringMultiProperty multiStringPropertyFrom(PropertyDescriptor<List<String>> desc) {
+
+        if (desc instanceof PropertyDescriptorWrapper<?>) {
+            return (StringMultiProperty) ((PropertyDescriptorWrapper<?>) desc).getPropertyDescriptor();
+        } else {
+            return (StringMultiProperty) desc;
+        }
+    }
+
 
     @Override
-    protected void update(PropertySource source, PropertyDescriptor<?> desc, List<Object> newValues) {
-    	source.setProperty((StringMultiProperty)desc, newValues.toArray(new String[newValues.size()]));
+    protected void update(PropertySource source, PropertyDescriptor<List<String>> desc, List<String> newValues) {
+        source.setProperty(desc, newValues);
     }
+
 
     @Override
-    protected Object addValueIn(Control widget, PropertyDescriptor<?> desc, PropertySource source) {
+    protected String addValueIn(Control widget, PropertyDescriptor<List<String>> desc, PropertySource source) {
 
-        String newValue = ((Text)widget).getText().trim();
-        if (StringUtil.isEmpty(newValue)) return null;
+        String newValue = ((Text) widget).getText().trim();
+        if (StringUtil.isEmpty(newValue)) {
+            return null;
+        }
 
-        String[] currentValues = (String[])valueFor(source, desc);
-        String[] newValues = CollectionUtil.addWithoutDuplicates(currentValues, newValue);
-        if (currentValues.length == newValues.length) return null;
-
-        source.setProperty((StringMultiProperty)desc, newValues);
-        return newValue;
+        List<String> currentValues = valueFor(source, desc);
+        int nAdded = CollectionUtil.addWithoutDuplicates(Collections.singleton(newValue), currentValues);
+        return (nAdded == 0) ? null : newValue;
     }
 
-    protected Object valueFrom(Control valueControl) {	// not necessary for this type
+
+    protected Object valueFrom(Control valueControl) {    // not necessary for this type
         return null;
     }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiTypeEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiTypeEditorFactory.java
@@ -59,7 +59,7 @@ public class MultiTypeEditorFactory extends AbstractMultiValueEditorFactory<Clas
             public void handleEvent(Event event) {
                 List<Class> newValue = currentTypes(textWidget);
                 List<Class> existingValue = valueFor(source, desc);
-                if (CollectionUtil.areSemanticEquals(existingValue, newValue)) {
+                if (existingValue != null && existingValue.equals(newValue)) {
                     return;
                 }
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiTypeEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiTypeEditorFactory.java
@@ -6,7 +6,7 @@ import java.util.List;
 import net.sourceforge.pmd.PropertyDescriptor;
 import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-import net.sourceforge.pmd.lang.rule.properties.PropertyDescriptorWrapper;
+import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 import net.sourceforge.pmd.lang.rule.properties.TypeMultiProperty;
 import net.sourceforge.pmd.util.ClassUtil;
 import net.sourceforge.pmd.util.CollectionUtil;

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiTypeEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiTypeEditorFactory.java
@@ -1,16 +1,8 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
-
-import net.sourceforge.pmd.PropertyDescriptor;
-import net.sourceforge.pmd.PropertySource;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
-import net.sourceforge.pmd.lang.rule.properties.TypeMultiProperty;
-import net.sourceforge.pmd.util.ClassUtil;
-import net.sourceforge.pmd.util.CollectionUtil;
-import net.sourceforge.pmd.util.StringUtil;
 
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
@@ -19,90 +11,60 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
 
+import net.sourceforge.pmd.PropertyDescriptor;
+import net.sourceforge.pmd.PropertySource;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
+import net.sourceforge.pmd.lang.rule.properties.TypeMultiProperty;
+import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
+import net.sourceforge.pmd.util.ClassUtil;
+import net.sourceforge.pmd.util.CollectionUtil;
+import net.sourceforge.pmd.util.StringUtil;
+
 /**
  * TODO - use new TypeText widget
  *
  * @author Brian Remedios
  */
-public class MultiTypeEditorFactory extends AbstractMultiValueEditorFactory {
+public class MultiTypeEditorFactory extends AbstractMultiValueEditorFactory<Class> {
 
-	public static final MultiTypeEditorFactory instance = new MultiTypeEditorFactory();
+    public static final MultiTypeEditorFactory instance = new MultiTypeEditorFactory();
 
-	private MultiTypeEditorFactory() { }
 
-    public PropertyDescriptor<?> createDescriptor(String name, String optionalDescription, Control[] otherData) {
-        return new TypeMultiProperty(name, "Type value " + name, new Class[] {String.class}, new String[] { "java.lang" } , 0.0f);
+    private MultiTypeEditorFactory() { }
+
+
+    public PropertyDescriptor<List<Class>> createDescriptor(String name, String optionalDescription, Control[] otherData) {
+        return new TypeMultiProperty(name, "Type value "
+            + name, new Class[] {String.class}, new String[] {"java.lang"}, 0.0f);
     }
 
-	public static String[] shortNamesFor(Class<?>[] types) {
-	    String[] typeNames = new String[types.length];
-        for (int i=0; i<typeNames.length; i++) {
-            typeNames[i] = ClassUtil.asShortestName(types[i]);
-        }
-        return typeNames;
-	}
 
-    protected void fillWidget(Text textWidget, PropertyDescriptor<?> desc, PropertySource source) {
-
-        Class<?>[] values = (Class[])valueFor(source, desc);
-        if (values == null) {
-            textWidget.setText("");
-            return;
-        }
-
-        textWidget.setText(values == null ? "" : asString(values));
-        adjustRendering(source, desc, textWidget);
-    }
-
-    private String asString(Class<?>[] types) {
-        String[] typeNames = shortNamesFor(types);
-        return StringUtil.asString(typeNames, delimiter + ' ');
-    }
-
-	private Class<?>[] currentTypes(Text textWidget) {
-
-	    String[] typeNames = textWidgetValues(textWidget);
-	    if (typeNames.length == 0) return ClassUtil.EMPTY_CLASS_ARRAY;
-
-	    List<Class<?>> types = new ArrayList<Class<?>>(typeNames.length);
-
-	    for (String typeName : typeNames) {
-	        Class<?> newType = TypeEditorFactory.typeFor(typeName);
-	        if (newType != null) types.add(newType);
-	    }
-	    return types.toArray(new Class[types.size()]);
-	}
-
-   private static TypeMultiProperty multiTypePropertyFrom(PropertyDescriptor<?> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-           return (TypeMultiProperty) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
-        } else {
-            return (TypeMultiProperty)desc;
-        }
-    }
-
-    protected Control addWidget(Composite parent, Object value, PropertyDescriptor<?> desc, PropertySource source) {
+    protected Control addWidget(Composite parent, Class value, PropertyDescriptor<List<Class>> desc, PropertySource
+        source) {
         TypeText typeWidget = new TypeText(parent, SWT.SINGLE | SWT.BORDER, true, "Enter type name");
         setValue(typeWidget, value);
         return typeWidget;
     }
 
-    protected void setValue(Control widget, Object value) {
 
-        Class<?> type = (Class<?>)value;
-        ((TypeText)widget).setType(type);
+    protected void setValue(Control widget, Class value) {
+        Class<?> type = (Class<?>) value;
+        ((TypeText) widget).setType(type);
     }
 
-    protected void configure(final Text textWidget, final PropertyDescriptor<?> desc, final PropertySource source, final ValueChangeListener listener) {
+
+    protected void configure(final Text textWidget, final PropertyDescriptor<List<Class>> desc,
+                             final PropertySource source, final ValueChangeListener listener) {
 
         final TypeMultiProperty tmp = multiTypePropertyFrom(desc);  // TODO - really necessary?
 
         textWidget.addListener(SWT.FocusOut, new Listener() {
             public void handleEvent(Event event) {
-                Class<?>[] newValue = currentTypes(textWidget);
-                Class<?>[] existingValue = (Class[])valueFor(source, tmp);
-                if (CollectionUtil.areSemanticEquals(existingValue, newValue)) return;
+                List<Class> newValue = currentTypes(textWidget);
+                List<Class> existingValue = valueFor(source, tmp);
+                if (CollectionUtil.areSemanticEquals(existingValue, newValue)) {
+                    return;
+                }
 
                 source.setProperty(tmp, newValue);
                 fillWidget(textWidget, desc, source);   // display the accepted values
@@ -113,25 +75,84 @@ public class MultiTypeEditorFactory extends AbstractMultiValueEditorFactory {
         });
     }
 
-    protected void update(PropertySource source, PropertyDescriptor<?> desc, List<Object> newValues) {
-    	source.setProperty((TypeMultiProperty)desc, newValues.toArray(new Class[newValues.size()]));
+
+    private static TypeMultiProperty multiTypePropertyFrom(PropertyDescriptor<?> desc) {
+
+        if (desc instanceof PropertyDescriptorWrapper<?>) {
+            return (TypeMultiProperty) ((PropertyDescriptorWrapper<?>) desc).getPropertyDescriptor();
+        } else {
+            return (TypeMultiProperty) desc;
+        }
     }
+
+
+    private List<Class> currentTypes(Text textWidget) {
+
+        List<String> typeNames = textWidgetValues(textWidget);
+        if (typeNames.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        List<Class> types = new ArrayList<Class>(typeNames.size());
+
+        for (String typeName : typeNames) {
+            Class newType = TypeEditorFactory.typeFor(typeName);
+            if (newType != null) {
+                types.add(newType);
+            }
+        }
+        return types;
+    }
+
+
+    protected void fillWidget(Text textWidget, PropertyDescriptor<List<Class>> desc, PropertySource source) {
+
+        List<Class> values = valueFor(source, desc);
+        if (values == null) {
+            textWidget.setText("");
+            return;
+        }
+
+        textWidget.setText(asString(values));
+        adjustRendering(source, desc, textWidget);
+    }
+
+
+    private String asString(List<Class> types) {
+        String[] typeNames = shortNamesFor(types.toArray(new Class<?>[types.size()]));
+        return StringUtil.asString(typeNames, delimiter + ' ');
+    }
+
+
+    public static String[] shortNamesFor(Class<?>[] types) {
+        String[] typeNames = new String[types.length];
+        for (int i = 0; i < typeNames.length; i++) {
+            typeNames[i] = ClassUtil.asShortestName(types[i]);
+        }
+        return typeNames;
+    }
+
+
+    protected void update(PropertySource source, PropertyDescriptor<List<Class>> desc, List<Class> newValues) {
+        source.setProperty(desc, newValues);
+    }
+
 
     @Override
-    protected Object addValueIn(Control widget, PropertyDescriptor<?> desc, PropertySource source) {
+    protected Class addValueIn(Control widget, PropertyDescriptor<List<Class>> desc, PropertySource source) {
 
-        Class<?> enteredValue = ((TypeText) widget).getType(true);
-        if (enteredValue == null) return null;
+        Class enteredValue = ((TypeText) widget).getType(true);
+        if (enteredValue == null) {
+            return null;
+        }
 
-        Class<?>[] currentValues = (Class[])valueFor(source, desc);
-        Class<?>[] newValues = CollectionUtil.addWithoutDuplicates(currentValues, enteredValue);
-        if (currentValues.length == newValues.length) return null;
-
-        source.setProperty((TypeMultiProperty)desc, newValues);
-        return enteredValue;
+        List<Class> currentValues = valueFor(source, desc);
+        int nAdded = CollectionUtil.addWithoutDuplicates(Collections.singleton(enteredValue), currentValues);
+        return nAdded == 0 ? null : enteredValue;
     }
 
-    protected Object valueFrom(Control valueControl) {	// not necessary for this type
+
+    protected List<Class> valueFrom(Control valueControl) {    // not necessary for this type
         return null;
     }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiTypeEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/MultiTypeEditorFactory.java
@@ -15,7 +15,6 @@ import net.sourceforge.pmd.PropertyDescriptor;
 import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
 import net.sourceforge.pmd.lang.rule.properties.TypeMultiProperty;
-import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 import net.sourceforge.pmd.util.ClassUtil;
 import net.sourceforge.pmd.util.CollectionUtil;
 import net.sourceforge.pmd.util.StringUtil;
@@ -56,33 +55,21 @@ public class MultiTypeEditorFactory extends AbstractMultiValueEditorFactory<Clas
     protected void configure(final Text textWidget, final PropertyDescriptor<List<Class>> desc,
                              final PropertySource source, final ValueChangeListener listener) {
 
-        final TypeMultiProperty tmp = multiTypePropertyFrom(desc);  // TODO - really necessary?
-
         textWidget.addListener(SWT.FocusOut, new Listener() {
             public void handleEvent(Event event) {
                 List<Class> newValue = currentTypes(textWidget);
-                List<Class> existingValue = valueFor(source, tmp);
+                List<Class> existingValue = valueFor(source, desc);
                 if (CollectionUtil.areSemanticEquals(existingValue, newValue)) {
                     return;
                 }
 
-                source.setProperty(tmp, newValue);
+                source.setProperty(desc, newValue);
                 fillWidget(textWidget, desc, source);   // display the accepted values
                 listener.changed(source, desc, newValue);
 
                 adjustRendering(source, desc, textWidget);
             }
         });
-    }
-
-
-    private static TypeMultiProperty multiTypePropertyFrom(PropertyDescriptor<?> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-            return (TypeMultiProperty) ((PropertyDescriptorWrapper<?>) desc).getPropertyDescriptor();
-        } else {
-            return (TypeMultiProperty) desc;
-        }
     }
 
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/StringEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/StringEditorFactory.java
@@ -1,13 +1,5 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
-import net.sourceforge.pmd.PropertyDescriptor;
-import net.sourceforge.pmd.PropertySource;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-import net.sourceforge.pmd.lang.rule.properties.PropertyDescriptorWrapper;
-import net.sourceforge.pmd.lang.rule.properties.StringProperty;
-import net.sourceforge.pmd.util.StringUtil;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
@@ -16,79 +8,78 @@ import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 import org.eclipse.swt.widgets.Text;
 
+import net.sourceforge.pmd.PropertyDescriptor;
+import net.sourceforge.pmd.PropertySource;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
+import net.sourceforge.pmd.lang.rule.properties.StringProperty;
+import net.sourceforge.pmd.util.StringUtil;
+
 /**
- *
  * @author Brian Remedios
  */
-public class StringEditorFactory extends AbstractEditorFactory {
+public class StringEditorFactory extends AbstractEditorFactory<String> {
 
-	public static final StringEditorFactory instance = new StringEditorFactory();
+    public static final StringEditorFactory instance = new StringEditorFactory();
 
-	protected StringEditorFactory() { }
 
-    public PropertyDescriptor<?> createDescriptor(String name, String description, Control[] otherData) {
+    protected StringEditorFactory() { }
+
+
+    public PropertyDescriptor<String> createDescriptor(String name, String description, Control[] otherData) {
 
         return new StringProperty(
-                name,
-                description,
-                otherData == null ? "" : (String)valueFrom(otherData[1]),
-                0.0f
-                );
+            name,
+            description,
+            otherData == null ? "" : valueFrom(otherData[1]),
+            0.0f
+        );
     }
 
 
-    protected Object valueFrom(Control valueControl) {
-        return ((Text)valueControl).getText();
+    protected String valueFrom(Control valueControl) {
+        return ((Text) valueControl).getText();
     }
 
-	/**
-	 * Method fillWidget.
-	 * @param textWidget Text
-	 * @param desc PropertyDescriptor<?>
-	 * @param rule Rule
-	 */
-	protected void fillWidget(Text textWidget, PropertyDescriptor<?> desc, PropertySource source) {
-		String val = (String)valueFor(source, desc);
-		textWidget.setText(val == null ? "" : val);
-		adjustRendering(source, desc, textWidget);
-	}
 
-	private static StringProperty stringPropertyFrom(PropertyDescriptor<?> desc) {
+    public Control newEditorOn(Composite parent, final PropertyDescriptor<String> desc, final PropertySource source,
+                               final ValueChangeListener listener, SizeChangeListener sizeListener) {
 
-	    if (desc instanceof PropertyDescriptorWrapper<?>) {
-	       return (StringProperty) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
-	       } else {
-	        return (StringProperty)desc;
-	     }
-	}
+        final Text text = new Text(parent, SWT.SINGLE | SWT.BORDER);
+        text.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
 
-	private void setValue(PropertySource source, StringProperty desc, String value) {
+        fillWidget(text, desc, source);
 
-	    if (!source.hasDescriptor(desc)) return;
-	    source.setProperty(desc, value);
-	}
-
-   public Control newEditorOn(Composite parent, final PropertyDescriptor<?> desc, final PropertySource source, final ValueChangeListener listener, SizeChangeListener sizeListener) {
-
-            final Text text =  new Text(parent, SWT.SINGLE | SWT.BORDER);
-            text.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-
-            fillWidget(text, desc, source);
-
-            final StringProperty sp = stringPropertyFrom(desc); // TODO - really necessary?
-
-            text.addListener(SWT.FocusOut, new Listener() {
-                public void handleEvent(Event event) {
-                    String newValue = text.getText().trim();
-                    String existingValue = (String)valueFor(source, sp);
-                    if (StringUtil.areSemanticEquals(existingValue, newValue)) return;
-
-                    setValue(source, sp, newValue);
-                    fillWidget(text, desc, source);     // redraw
-                    listener.changed(source, desc, newValue);
+        text.addListener(SWT.FocusOut, new Listener() {
+            public void handleEvent(Event event) {
+                String newValue = text.getText().trim();
+                String existingValue = valueFor(source, desc);
+                if (StringUtil.areSemanticEquals(existingValue, newValue)) {
+                    return;
                 }
-            });
 
-            return text;
+                setValue(source, desc, newValue);
+                fillWidget(text, desc, source);     // redraw
+                listener.changed(source, desc, newValue);
+            }
+        });
+
+        return text;
+    }
+
+
+    protected void fillWidget(Text textWidget, PropertyDescriptor<String> desc, PropertySource source) {
+        String val = valueFor(source, desc);
+        textWidget.setText(val == null ? "" : val);
+        adjustRendering(source, desc, textWidget);
+    }
+
+
+    private void setValue(PropertySource source, PropertyDescriptor<String> desc, String value) {
+
+        if (!source.hasDescriptor(desc)) {
+            return;
         }
+        source.setProperty(desc, value);
+    }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/TypeEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/TypeEditorFactory.java
@@ -12,7 +12,6 @@ import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
 import net.sourceforge.pmd.lang.rule.properties.TypeProperty;
-import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 import net.sourceforge.pmd.util.ClassUtil;
 
 
@@ -53,8 +52,6 @@ public class TypeEditorFactory extends AbstractEditorFactory<Class> {
 
         fillWidget(typeText, desc, source);
 
-        final TypeProperty tp = typePropertyFrom(desc);
-
         Listener wereDoneListener = new Listener() {
             public void handleEvent(Event event) {
                 Class<?> newValue = typeText.getType(true);
@@ -62,12 +59,12 @@ public class TypeEditorFactory extends AbstractEditorFactory<Class> {
                     return;
                 }
 
-                Class<?> existingValue = (Class<?>) valueFor(source, tp);
+                Class<?> existingValue = (Class<?>) valueFor(source, desc);
                 if (existingValue == newValue) {
                     return;
                 }
 
-                source.setProperty(tp, newValue);
+                source.setProperty(desc, newValue);
                 listener.changed(source, desc, newValue);
 
                 adjustRendering(source, desc, typeText);
@@ -84,16 +81,6 @@ public class TypeEditorFactory extends AbstractEditorFactory<Class> {
 
         Class<?> type = (Class<?>) valueFor(source, desc);
         textWidget.setType(type);
-    }
-
-
-    private static TypeProperty typePropertyFrom(PropertyDescriptor<Class> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-            return (TypeProperty) ((PropertyDescriptorWrapper<Class>) desc).getPropertyDescriptor();
-        } else {
-            return (TypeProperty) desc;
-        }
     }
 
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/TypeEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/TypeEditorFactory.java
@@ -4,7 +4,7 @@ import net.sourceforge.pmd.PropertyDescriptor;
 import net.sourceforge.pmd.PropertySource;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
 import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-import net.sourceforge.pmd.lang.rule.properties.PropertyDescriptorWrapper;
+import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
 import net.sourceforge.pmd.lang.rule.properties.TypeProperty;
 import net.sourceforge.pmd.util.ClassUtil;
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/TypeEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/TypeEditorFactory.java
@@ -1,13 +1,5 @@
 package net.sourceforge.pmd.eclipse.ui.preferences.editors;
 
-import net.sourceforge.pmd.PropertyDescriptor;
-import net.sourceforge.pmd.PropertySource;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
-import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
-import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
-import net.sourceforge.pmd.lang.rule.properties.TypeProperty;
-import net.sourceforge.pmd.util.ClassUtil;
-
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.widgets.Composite;
@@ -15,86 +7,108 @@ import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.Event;
 import org.eclipse.swt.widgets.Listener;
 
+import net.sourceforge.pmd.PropertyDescriptor;
+import net.sourceforge.pmd.PropertySource;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.SizeChangeListener;
+import net.sourceforge.pmd.eclipse.ui.preferences.br.ValueChangeListener;
+import net.sourceforge.pmd.lang.rule.properties.TypeProperty;
+import net.sourceforge.pmd.lang.rule.properties.wrappers.PropertyDescriptorWrapper;
+import net.sourceforge.pmd.util.ClassUtil;
+
 
 /**
- *
  * @author Brian Remedios
  */
-public class TypeEditorFactory extends AbstractEditorFactory {
+public class TypeEditorFactory extends AbstractEditorFactory<Class> {
 
-	public static final TypeEditorFactory instance = new TypeEditorFactory();
+    public static final TypeEditorFactory instance = new TypeEditorFactory();
 
-	private TypeEditorFactory() { }
 
-    public PropertyDescriptor<?> createDescriptor(String name, String description, Control[] otherData) {
+    private TypeEditorFactory() { }
+
+
+    public PropertyDescriptor<Class> createDescriptor(String name, String description, Control[] otherData) {
 
         return new TypeProperty(
-                name,
-                description,
-                String.class,
-                new String[] { "java.lang" },
-                0.0f
-                );
+            name,
+            description,
+            String.class,
+            new String[] {"java.lang"},
+            0.0f
+        );
     }
 
-	public static Class<?> typeFor(String typeName) {
 
-        Class<?> newType = ClassUtil.getTypeFor(typeName);    // try for well-known types first
-        if (newType != null) return newType;
+    protected Class valueFrom(Control valueControl) {
+        return ((TypeText) valueControl).getType(false);
+    }
 
-        try {
-            return Class.forName(typeName);
-            } catch (ClassNotFoundException e) {
-               return null;
+
+    public Control newEditorOn(Composite parent, final PropertyDescriptor<Class> desc, final PropertySource source,
+                               final ValueChangeListener listener, SizeChangeListener sizeListener) {
+
+        final TypeText typeText = new TypeText(parent,
+                                               SWT.SINGLE | SWT.BORDER, true, "Enter a type name");  // TODO  i18l
+        typeText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
+
+        fillWidget(typeText, desc, source);
+
+        final TypeProperty tp = typePropertyFrom(desc);
+
+        Listener wereDoneListener = new Listener() {
+            public void handleEvent(Event event) {
+                Class<?> newValue = typeText.getType(true);
+                if (newValue == null) {
+                    return;
+                }
+
+                Class<?> existingValue = (Class<?>) valueFor(source, tp);
+                if (existingValue == newValue) {
+                    return;
+                }
+
+                source.setProperty(tp, newValue);
+                listener.changed(source, desc, newValue);
+
+                adjustRendering(source, desc, typeText);
             }
-    }
-
-    protected Object valueFrom(Control valueControl) {
-        return ((TypeText)valueControl).getType(false);
-    }
-
-	protected void fillWidget(TypeText textWidget, PropertyDescriptor<?> desc, PropertySource source) {
-
-		Class<?> type = (Class<?>)valueFor(source, desc);
-		textWidget.setType(type);
-	}
-
-    private static TypeProperty typePropertyFrom(PropertyDescriptor<?> desc) {
-
-        if (desc instanceof PropertyDescriptorWrapper<?>) {
-           return (TypeProperty) ((PropertyDescriptorWrapper<?>)desc).getPropertyDescriptor();
-        } else {
-            return (TypeProperty)desc;
-        }
-    }
-
-    public Control newEditorOn(Composite parent, final PropertyDescriptor<?> desc, final PropertySource source, final ValueChangeListener listener, SizeChangeListener sizeListener) {
-
-         final TypeText typeText = new TypeText(parent, SWT.SINGLE | SWT.BORDER, true, "Enter a type name");  // TODO  i18l
-         typeText.setLayoutData(new GridData(GridData.FILL_HORIZONTAL));
-
-         fillWidget(typeText, desc, source);
-
-         final TypeProperty tp = typePropertyFrom(desc);
-
-         Listener wereDoneListener = new Listener() {
-             public void handleEvent(Event event) {
-                 Class<?> newValue = typeText.getType(true);
-                 if (newValue == null) return;
-
-                 Class<?> existingValue = (Class<?>)valueFor(source, tp);
-                 if (existingValue == newValue) return;
-
-                 source.setProperty(tp, newValue);
-                 listener.changed(source, desc, newValue);
-
-                 adjustRendering(source, desc, typeText);
-                 }
-          	};
+        };
 
         typeText.addListener(SWT.FocusOut, wereDoneListener);
         typeText.addListener(SWT.DefaultSelection, wereDoneListener);
         return typeText;
-     }
+    }
+
+
+    protected void fillWidget(TypeText textWidget, PropertyDescriptor<Class> desc, PropertySource source) {
+
+        Class<?> type = (Class<?>) valueFor(source, desc);
+        textWidget.setType(type);
+    }
+
+
+    private static TypeProperty typePropertyFrom(PropertyDescriptor<Class> desc) {
+
+        if (desc instanceof PropertyDescriptorWrapper<?>) {
+            return (TypeProperty) ((PropertyDescriptorWrapper<Class>) desc).getPropertyDescriptor();
+        } else {
+            return (TypeProperty) desc;
+        }
+    }
+
+
+    public static Class<?> typeFor(String typeName) {
+
+        Class<?> newType = ClassUtil.getTypeFor(typeName);    // try for well-known types first
+        if (newType != null) {
+            return newType;
+        }
+
+        try {
+            return Class.forName(typeName);
+        } catch (ClassNotFoundException e) {
+            return null;
+        }
+    }
 
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/panelmanagers/FormArranger.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/panelmanagers/FormArranger.java
@@ -21,7 +21,7 @@ import net.sourceforge.pmd.eclipse.ui.preferences.editors.SWTUtil;
 import net.sourceforge.pmd.eclipse.util.ResourceManager;
 import net.sourceforge.pmd.eclipse.util.Util;
 import net.sourceforge.pmd.lang.rule.XPathRule;
-import net.sourceforge.pmd.lang.rule.properties.factories.PropertyDescriptorUtil;
+import net.sourceforge.pmd.lang.rule.properties.PropertyDescriptorUtil;
 
 import org.eclipse.jface.window.Window;
 import org.eclipse.swt.SWT;

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/panelmanagers/XPathPanelManager.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/panelmanagers/XPathPanelManager.java
@@ -145,7 +145,7 @@ public class XPathPanelManager extends AbstractRulePanelManager {
             public void widgetSelected(SelectionEvent e) {
                 Rule rule = soleRule();
                 int selectionIdx = xpathVersionField.getSelectionIndex();
-                Object newValue = ep.choices()[selectionIdx][1];
+                String newValue = (String) ep.choices()[selectionIdx][1];
                 if (newValue.equals(rule.getProperty(ep))) return;
 
                 rule.setProperty(ep, newValue);

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/panelmanagers/XPathPanelManager.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/panelmanagers/XPathPanelManager.java
@@ -139,13 +139,13 @@ public class XPathPanelManager extends AbstractRulePanelManager {
         gridData.horizontalSpan = 1;
         gridData.grabExcessHorizontalSpace = false;
         xpathVersionField.setLayoutData(gridData);
-        xpathVersionField.setItems(SWTUtil.labelsIn(ep.choices(), 0));
+        xpathVersionField.setItems(SWTUtil.labelsIn(EnumerationEditorFactory.choices(ep), 0));
 
         xpathVersionField.addSelectionListener(new SelectionAdapter() {
             public void widgetSelected(SelectionEvent e) {
                 Rule rule = soleRule();
                 int selectionIdx = xpathVersionField.getSelectionIndex();
-                String newValue = (String) ep.choices()[selectionIdx][1];
+                String newValue = (String) EnumerationEditorFactory.choices(ep)[selectionIdx][1];
                 if (newValue.equals(rule.getProperty(ep))) return;
 
                 rule.setProperty(ep, newValue);
@@ -159,7 +159,8 @@ public class XPathPanelManager extends AbstractRulePanelManager {
     private void configureVersionFieldFor(Rule rule) {
 
         Object value = rule.getProperty(XPathRule.VERSION_DESCRIPTOR);
-        int selectionIdx = EnumerationEditorFactory.indexOf(value, XPathRule.VERSION_DESCRIPTOR.choices());
+        int selectionIdx = EnumerationEditorFactory.indexOf(value, 
+                                                            EnumerationEditorFactory.choices(XPathRule.VERSION_DESCRIPTOR));
         if (selectionIdx >= 0) xpathVersionField.select(selectionIdx);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <tycho.version>0.26.0</tycho.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <pmd.version>5.8.0</pmd.version>
+    <pmd.version>6.0.0-SNAPSHOT</pmd.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
   </properties>
 


### PR DESCRIPTION
This makes the plugin compatible with the changes in pmd/pmd#479

Not much to say about it, the changes are in the same vein as pmd/pmd#479, mainly being that property editors are now generic for tighter type safety.