### PR TITLE
Global Priority Filter for Violations Overview/Outline

### DIFF
--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/PMDPlugin.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/PMDPlugin.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Layout;
@@ -42,6 +43,10 @@ import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.graphics.RGB;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IDecoratorManager;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IEditorReference;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
@@ -80,563 +85,582 @@ import net.sourceforge.pmd.lang.java.JavaLanguageModule;
  */
 public class PMDPlugin extends AbstractUIPlugin {
 
-    private static File pluginFolder;
-
-    private FileChangeReviewer changeReviewer;
-
-    private Map<RGB, Color> coloursByRGB = new HashMap<RGB, Color>();
-
-    public static final String PLUGIN_ID = "net.sourceforge.pmd.eclipse.plugin";
-
-    private static Map<IProject, IJavaProject> javaProjectsByIProject = new HashMap<IProject, IJavaProject>();
-
-    // The shared instance
-    private static PMDPlugin plugin;
-
-    public static String version = "unknown";
-
-    private static final Integer[] PRIORITY_VALUES = new Integer[] { Integer.valueOf(1), Integer.valueOf(2),
-        Integer.valueOf(3), Integer.valueOf(4), Integer.valueOf(5), };
-
-    private static final Logger LOG = Logger.getLogger(PMDPlugin.class);
-
-    private StringTable stringTable; // NOPMD by Herlin on 11/10/06 00:22
-
-    public static final String ROOT_LOG_ID = "net.sourceforge.pmd";
-    private static final String PMD_ECLIPSE_APPENDER_NAME = "PMDEclipseAppender";
-    private IPreferencesFactory preferencesFactory = new PreferencesFactoryImpl();
-    private IPropertiesFactory propertiesFactory = new PropertiesFactoryImpl();
-
-    private final IRuleSetManager ruleSetManager = new RuleSetManagerImpl(); // NOPMD:SingularField
-
-    /**
-     * The constructor
-     */
-    public PMDPlugin() {
-    }
-
-    public Color colorFor(RGB rgb) {
-
-        Color color = coloursByRGB.get(rgb);
-        if (color != null) {
-            return color;
-        }
-
-        color = new Color(null, rgb.red, rgb.green, rgb.blue);
-        coloursByRGB.put(rgb, color);
-
-        return color;
-    }
-
-    public static void setJavaClassLoader(PMDConfiguration config, IProject project) {
-
-        IPreferences preferences = getDefault().loadPreferences();
-        try {
-            if (preferences.isProjectBuildPathEnabled() && project.hasNature(JavaCore.NATURE_ID)) {
-                config.setClassLoader(new JavaProjectClassLoader(config.getClass().getClassLoader(), project));
-            }
-        } catch (CoreException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * Return the Java language version for the resources found within the
-     * specified project or null if it isn't a Java project or a Java version we
-     * don't support yet.
-     * 
-     * @param project
-     * @return
-     */
-    public static LanguageVersion javaVersionFor(IProject project) {
-
-        IJavaProject jProject = javaProjectsByIProject.get(project);
-        if (jProject == null) {
-            jProject = JavaCore.create(project);
-            javaProjectsByIProject.put(project, jProject);
-        }
-
-        if (jProject.exists()) {
-            String compilerCompliance = jProject.getOption(JavaCore.COMPILER_COMPLIANCE, true);
-            return LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion(compilerCompliance);
-        }
-        return null;
-    }
-
-    public static IClasspathEntry buildSourceClassPathEntryFor(IProject project) {
-        IJavaProject jProject = javaProjectsByIProject.get(project);
-        if (jProject == null) {
-            jProject = JavaCore.create(project);
-            javaProjectsByIProject.put(project, jProject);
-        }
-        if (jProject.exists()) {
-            try {
-                if (jProject.getRawClasspath() != null) {
-                    for (IClasspathEntry entry : jProject.getRawClasspath()) {
-                        if (entry.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
-                            return entry;
-                        }
-                    }
-                }
-            } catch (JavaModelException e) {
-                LOG.error("Couldn't determine source classpath", e);
-            }
-        }
-        return null;
-    }
-
-    private void disposeResources() {
-
-        disposeAll(coloursByRGB.values());
-    }
-
-    public static void disposeAll(Collection<Color> colors) {
-        for (Color color : colors) {
-            color.dispose();
-        }
-    }
-
-    public static File getPluginFolder() {
-
-        if (pluginFolder == null) {
-            URL url = Platform.getBundle(PLUGIN_ID).getEntry("/");
-            try {
-                url = FileLocator.resolve(url);
-            } catch (IOException ex) {
-                ex.printStackTrace();
-            }
-            pluginFolder = new File(url.getPath());
-        }
-
-        return pluginFolder;
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.
-     * BundleContext )
-     */
-    public void start(BundleContext context) throws Exception {
-        super.start(context);
-        plugin = this;
-
-        // this needs to be executed before the preferences are loaded, because
-        // the standard
-        // rulesets are needed for the default active rules.
-        registerStandardRuleSets();
-
-        IPreferences prefs = loadPreferences();
-        configureLogs(prefs);
-        registerAdditionalRuleSets();
-        fileChangeListenerEnabled(prefs.isCheckAfterSaveEnabled());
-
-        // if a project is deleted, remove the cached project properties
-        ResourcesPlugin.getWorkspace().addResourceChangeListener(new IResourceChangeListener() {
-            public void resourceChanged(IResourceChangeEvent arg0) {
-                if (arg0.getType() == IResourceChangeEvent.PRE_DELETE && arg0.getResource() instanceof IProject) {
-                    getPropertiesManager().removeProjectProperties((IProject) arg0.getResource());
-                }
-            }
-        });
-
-        version = context.getBundle().getHeaders().get("Bundle-Version");
-    }
-
-    public void fileChangeListenerEnabled(boolean flag) {
-
-        IWorkspace workspace = ResourcesPlugin.getWorkspace();
-
-        if (flag) {
-            if (changeReviewer == null) {
-                changeReviewer = new FileChangeReviewer();
-            }
-            workspace.addResourceChangeListener(changeReviewer);
-        } else {
-            if (changeReviewer != null) {
-                workspace.removeResourceChangeListener(changeReviewer);
-                changeReviewer = null;
-            }
-        }
-    }
-
-    /*
-     * (non-Javadoc)
-     * 
-     * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.
-     * BundleContext )
-     */
-    public void stop(BundleContext context) throws Exception {
-
-        fileChangeListenerEnabled(false);
-
-        plugin = null;
-        disposeResources();
-        ShapePainter.disposeAll();
-        ResourceManager.dispose();
-        super.stop(context);
-    }
-
-    /**
-     * Returns the shared instance
-     *
-     * @return the shared instance
-     */
-    public static PMDPlugin getDefault() {
-        return plugin;
-    }
-
-    /**
-     * Returns an image descriptor for the image file at the given plug-in
-     * relative path.
-     *
-     * @param path
-     *            the path
-     * @return the image descriptor
-     */
-    public static ImageDescriptor getImageDescriptor(String path) {
-        return AbstractUIPlugin.imageDescriptorFromPlugin("net.sourceforge.pmd.eclipse.plugin", path);
-    }
-
-    /**
-     * Get an image corresponding to the severity
-     */
-    public Image getImage(String key, String iconPath) {
-        ImageRegistry registry = getImageRegistry();
-        Image image = registry.get(key);
-        if (image == null) {
-            ImageDescriptor descriptor = getImageDescriptor(iconPath);
-            if (descriptor != null) {
-                registry.put(key, descriptor);
-                image = registry.get(key);
-            }
-        }
-
-        return image;
-    }
-
-    /**
-     * Helper method to log error
-     *
-     * @see IStatus
-     */
-    public void logError(String message, Throwable t) {
-        getLog().log(new Status(IStatus.ERROR, getBundle().getSymbolicName(), 0, message + t.getMessage(), t));
-        if (LOG != null) {
-            LOG.error(message, t);
-        }
-    }
-
-    /**
-     * Helper method to log error
-     *
-     * @see IStatus
-     */
-    public void logError(IStatus status) {
-        getLog().log(status);
-        if (LOG != null) {
-            LOG.error(status.getMessage(), status.getException());
-        }
-    }
-
-    /**
-     * Helper method to display error
-     */
-    public void showError(final String message, final Throwable t) {
-        logError(message, t);
-        Display.getDefault().syncExec(new Runnable() {
-
-            public void run() {
-                String errTitle = getStringTable().getString(StringKeys.ERROR_TITLE);
-                MessageDialog.openError(Display.getCurrent().getActiveShell(), errTitle,
-                        message + "\n" + String.valueOf(t));
-            }
-        });
-    }
-
-    /**
-     * Helper method to display a non-logged user error
-     */
-    public void showUserError(final String message) {
-
-        Display.getDefault().syncExec(new Runnable() {
-
-            public void run() {
-                String errTitle = getStringTable().getString(StringKeys.ERROR_TITLE);
-                MessageDialog.openError(Display.getCurrent().getActiveShell(), errTitle, message);
-            }
-        });
-    }
-
-    /**
-     * @return an instance of the string table
-     */
-    public StringTable getStringTable() {
-        if (stringTable == null) {
-            stringTable = new StringTable();
-        }
-
-        return stringTable;
-    }
-
-    /**
-     * @return the priority values
-     * @deprecated
-     */
-    public Integer[] getPriorityValues() {
-        return PRIORITY_VALUES;
-    }
-
-    /**
-     * Load the PMD plugin preferences
-     */
-    public IPreferences loadPreferences() {
-        return getPreferencesManager().loadPreferences();
-    }
-
-    /**
-     * @return the plugin preferences manager
-     */
-    public IPreferencesManager getPreferencesManager() {
-        return preferencesFactory.getPreferencesManager();
-    }
-
-    /**
-     * @return the plugin project properties manager
-     */
-    public IProjectPropertiesManager getPropertiesManager() {
-        return propertiesFactory.getProjectPropertiesManager();
-    }
-
-    /**
-     * @param project
-     *            a workspace project
-     * @return the PMD properties for that project
-     */
-    public IProjectProperties loadProjectProperties(IProject project) throws PropertiesException {
-        return getPropertiesManager().loadProjectProperties(project);
-    }
-
-    /**
-     * Helper method to log information
-     *
-     * @see IStatus
-     */
-    public void logInformation(String message) {
-        getLog().log(new Status(IStatus.INFO, getBundle().getSymbolicName(), 0, message, null));
-    }
-
-    public void logWarn(String message) {
-        getLog().log(new Status(IStatus.WARNING, getBundle().getSymbolicName(), 0, message, null));
-    }
-
-    /**
-     * @return an instance of an AST writer
-     */
-    public IAstWriter getAstWriter() {
-        return new WriterFactoryImpl().getAstWriter();
-    }
-
-    /**
-     * @return an instance of a ruleset writer
-     */
-    public IRuleSetWriter getRuleSetWriter() {
-        return new WriterFactoryImpl().getRuleSetWriter();
-    }
-
-    /**
-     * Apply the log preferences
-     */
-    public void applyLogPreferences(IPreferences preferences) {
-        Logger log = Logger.getLogger(ROOT_LOG_ID);
-        log.setLevel(preferences.getLogLevel());
-        RollingFileAppender appender = (RollingFileAppender) log.getAppender(PMD_ECLIPSE_APPENDER_NAME);
-        if (appender == null) {
-            configureLogs(preferences);
-        } else if (!appender.getFile().equals(preferences.getLogFileName())) {
-            appender.setFile(preferences.getLogFileName());
-            appender.activateOptions();
-        }
-    }
-
-    /**
-     * Configure the logging
-     *
-     */
-    private void configureLogs(IPreferences preferences) {
-        try {
-            Layout layout = new PatternLayout("%d{yyyy/MM/dd HH:mm:ss,SSS} %-5p %-32c{1} %m%n");
-
-            RollingFileAppender appender = new RollingFileAppender(layout, preferences.getLogFileName());
-            appender.setName(PMD_ECLIPSE_APPENDER_NAME);
-            appender.setMaxBackupIndex(1);
-            appender.setMaxFileSize("10MB");
-
-            Logger.getRootLogger().addAppender(new ConsoleAppender(layout));
-            Logger.getRootLogger().setLevel(Level.WARN);
-            Logger.getRootLogger().setAdditivity(false);
-
-            Logger.getLogger(ROOT_LOG_ID).addAppender(appender);
-            Logger.getLogger(ROOT_LOG_ID).setLevel(preferences.getLogLevel());
-            Logger.getLogger(ROOT_LOG_ID).setAdditivity(false);
-
-        } catch (IOException e) {
-            logError("IO Exception when configuring logging.", e);
-        }
-    }
-
-    /**
-     * @return the ruleset manager instance
-     */
-    public final IRuleSetManager getRuleSetManager() {
-        return ruleSetManager;
-    }
-
-    /**
-     * Logs inside the Eclipse environment
-     *
-     * @param severity
-     *            the severity of the log (IStatus code)
-     * @param message
-     *            the message to log
-     * @param t
-     *            a possible throwable, may be null
-     */
-    public final void log(final int severity, final String message, final Throwable t) {
-        final Bundle bundle = getBundle();
-        if (bundle != null) {
-            getLog().log(new Status(severity, bundle.getSymbolicName(), 0, message, t));
-        }
-
-        // TODO : when bundle is not created yet (ie at startup), we cannot log
-        // ; find a way to log.
-    }
-
-    /**
-     * Registering the standard rulesets
-     *
-     */
-    private void registerStandardRuleSets() {
-
-        final RuleSetFactory factory = new RuleSetFactory();
-        try {
-            Iterator<RuleSet> iterator = factory.getRegisteredRuleSets();
-            final IRuleSetManager manager = getRuleSetManager();
-            RuleSet ruleSet;
-            while (iterator.hasNext()) {
-                ruleSet = iterator.next();
-                manager.registerRuleSet(ruleSet);
-                manager.registerDefaultRuleSet(ruleSet);
-            }
-        } catch (RuleSetNotFoundException e) {
-            log(IStatus.WARNING, "Problem getting all registered PMD RuleSets", e);
-        }
-    }
-
-    /**
-     * Register additional rulesets that may be provided by a fragment. Find
-     * extension points implementation and call them
-     *
-     */
-    private void registerAdditionalRuleSets() {
-        try {
-            final RuleSetsExtensionProcessor processor = new RuleSetsExtensionProcessor(getRuleSetManager());
-            processor.process();
-        } catch (CoreException e) {
-            log(IStatus.ERROR, "Error when processing RuleSets extensions", e);
-        }
-    }
-
-    public RuleLabelDecorator ruleLabelDecorator() {
-        IDecoratorManager mgr = getWorkbench().getDecoratorManager();
-        // TODO don't use a raw string...urgh
-        return (RuleLabelDecorator) mgr.getBaseLabelProvider("net.sourceforge.pmd.eclipse.plugin.RuleLabelDecorator");
-    }
-
-    public void changedFiles(Collection<IFile> changedFiles) {
-
-        RuleLabelDecorator rld = ruleLabelDecorator();
-        if (rld == null) {
-            return;
-        }
-
-        Collection<IResource> withParents = new HashSet<IResource>(changedFiles.size() * 2);
-        withParents.addAll(changedFiles);
-        for (IFile file : changedFiles) {
-            IResource parent = file.getParent();
-            while (parent != null) {
-                withParents.add(parent);
-                parent = parent.getParent();
-            }
-        }
-
-        rld.changed(withParents);
-    }
-
-    private void addFilesTo(IResource resource, Collection<IResource> allKids) {
-
-        if (resource instanceof IFile) {
-            allKids.add(resource);
-            return;
-        }
-
-        if (resource instanceof IFolder) {
-            IFolder folder = (IFolder) resource;
-            IResource[] kids = null;
-            try {
-                kids = folder.members();
-            } catch (CoreException e) {
-                e.printStackTrace();
-            }
-            addKids(allKids, kids);
-
-            allKids.add(folder);
-            return;
-        }
-
-        if (resource instanceof IProject) {
-            IProject project = (IProject) resource;
-            IResource[] kids = null;
-            try {
-                kids = project.members();
-            } catch (CoreException e) {
-                e.printStackTrace();
-            }
-            addKids(allKids, kids);
-            allKids.add(project);
-            return;
-        }
-    }
-
-    private void addKids(Collection<IResource> allKids, IResource[] kids) {
-
-        if (kids == null) {
-            return;
-        }
-
-        for (IResource irc : kids) {
-            if (irc instanceof IFile) {
-                allKids.add(irc);
-                continue;
-            }
-            if (irc instanceof IFolder) {
-                addFilesTo(irc, allKids);
-            }
-        }
-    }
-
-    public void removedMarkersIn(IResource resource) {
-
-        RuleLabelDecorator decorator = ruleLabelDecorator();
-        if (decorator == null) {
-            return;
-        }
-
-        Collection<IResource> changes = new ArrayList<IResource>();
-
-        addFilesTo(resource, changes);
-
-        decorator.changed(changes);
-    }
+	private static File pluginFolder;
+
+	private FileChangeReviewer changeReviewer;
+
+	private Map<RGB, Color> coloursByRGB = new HashMap<RGB, Color>();
+
+	public static final String PLUGIN_ID = "net.sourceforge.pmd.eclipse.plugin";
+
+	private static Map<IProject, IJavaProject> javaProjectsByIProject = new HashMap<IProject, IJavaProject>();
+
+	// The shared instance
+	private static PMDPlugin plugin;
+
+	public static String version = "unknown";
+
+	private static final Integer[] PRIORITY_VALUES = new Integer[] { Integer.valueOf(1), Integer.valueOf(2),
+			Integer.valueOf(3), Integer.valueOf(4), Integer.valueOf(5), };
+
+	private static final Logger LOG = Logger.getLogger(PMDPlugin.class);
+
+	private StringTable stringTable; // NOPMD by Herlin on 11/10/06 00:22
+
+	public static final String ROOT_LOG_ID = "net.sourceforge.pmd";
+	private static final String PMD_ECLIPSE_APPENDER_NAME = "PMDEclipseAppender";
+	private IPreferencesFactory preferencesFactory = new PreferencesFactoryImpl();
+	private IPropertiesFactory propertiesFactory = new PropertiesFactoryImpl();
+
+	private final IRuleSetManager ruleSetManager = new RuleSetManagerImpl(); // NOPMD:SingularField
+
+	/**
+	 * The constructor
+	 */
+	public PMDPlugin() {
+	}
+
+	public Color colorFor(RGB rgb) {
+
+		Color color = coloursByRGB.get(rgb);
+		if (color != null) {
+			return color;
+		}
+
+		color = new Color(null, rgb.red, rgb.green, rgb.blue);
+		coloursByRGB.put(rgb, color);
+
+		return color;
+	}
+
+	public static void setJavaClassLoader(PMDConfiguration config, IProject project) {
+
+		IPreferences preferences = getDefault().loadPreferences();
+		try {
+			if (preferences.isProjectBuildPathEnabled() && project.hasNature(JavaCore.NATURE_ID)) {
+				config.setClassLoader(new JavaProjectClassLoader(config.getClass().getClassLoader(), project));
+			}
+		} catch (CoreException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * Return the Java language version for the resources found within the specified
+	 * project or null if it isn't a Java project or a Java version we don't support
+	 * yet.
+	 * 
+	 * @param project
+	 * @return
+	 */
+	public static LanguageVersion javaVersionFor(IProject project) {
+
+		IJavaProject jProject = javaProjectsByIProject.get(project);
+		if (jProject == null) {
+			jProject = JavaCore.create(project);
+			javaProjectsByIProject.put(project, jProject);
+		}
+
+		if (jProject.exists()) {
+			String compilerCompliance = jProject.getOption(JavaCore.COMPILER_COMPLIANCE, true);
+			return LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion(compilerCompliance);
+		}
+		return null;
+	}
+
+	public static IClasspathEntry buildSourceClassPathEntryFor(IProject project) {
+		IJavaProject jProject = javaProjectsByIProject.get(project);
+		if (jProject == null) {
+			jProject = JavaCore.create(project);
+			javaProjectsByIProject.put(project, jProject);
+		}
+		if (jProject.exists()) {
+			try {
+				if (jProject.getRawClasspath() != null) {
+					for (IClasspathEntry entry : jProject.getRawClasspath()) {
+						if (entry.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
+							return entry;
+						}
+					}
+				}
+			} catch (JavaModelException e) {
+				LOG.error("Couldn't determine source classpath", e);
+			}
+		}
+		return null;
+	}
+
+	private void disposeResources() {
+
+		disposeAll(coloursByRGB.values());
+	}
+
+	public static void disposeAll(Collection<Color> colors) {
+		for (Color color : colors) {
+			color.dispose();
+		}
+	}
+
+	public static File getPluginFolder() {
+
+		if (pluginFolder == null) {
+			URL url = Platform.getBundle(PLUGIN_ID).getEntry("/");
+			try {
+				url = FileLocator.resolve(url);
+			} catch (IOException ex) {
+				ex.printStackTrace();
+			}
+			pluginFolder = new File(url.getPath());
+		}
+
+		return pluginFolder;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#start(org.osgi.framework.
+	 * BundleContext )
+	 */
+	public void start(BundleContext context) throws Exception {
+		super.start(context);
+		plugin = this;
+
+		// this needs to be executed before the preferences are loaded, because
+		// the standard
+		// rulesets are needed for the default active rules.
+		registerStandardRuleSets();
+
+		IPreferences prefs = loadPreferences();
+		configureLogs(prefs);
+		registerAdditionalRuleSets();
+		fileChangeListenerEnabled(prefs.isCheckAfterSaveEnabled());
+
+		// if a project is deleted, remove the cached project properties
+		ResourcesPlugin.getWorkspace().addResourceChangeListener(new IResourceChangeListener() {
+			public void resourceChanged(IResourceChangeEvent arg0) {
+				if (arg0.getType() == IResourceChangeEvent.PRE_DELETE && arg0.getResource() instanceof IProject) {
+					getPropertiesManager().removeProjectProperties((IProject) arg0.getResource());
+				}
+			}
+		});
+
+		version = context.getBundle().getHeaders().get("Bundle-Version");
+	}
+
+	/**
+	 * Get a list of all the files that are open in eclipse currently
+	 * 
+	 * @return
+	 */
+	public Set<IFile> getOpenFiles() {
+		Set<IFile> files = new HashSet<IFile>();
+		IEditorReference[] refs = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage()
+				.getEditorReferences();
+		if (refs.length > 0) {
+			final IWorkbenchPart part = refs[0].getPart(true);
+			IEditorPart[] editors = part.getSite().getPage().getEditors();
+			for (IEditorPart editor : editors) {
+				files.add(editor.getEditorInput().getAdapter(IFile.class));
+			}
+		}
+		return files;
+	}
+
+	public void fileChangeListenerEnabled(boolean flag) {
+
+		IWorkspace workspace = ResourcesPlugin.getWorkspace();
+
+		if (flag) {
+			if (changeReviewer == null) {
+				changeReviewer = new FileChangeReviewer();
+			}
+			workspace.addResourceChangeListener(changeReviewer);
+		} else {
+			if (changeReviewer != null) {
+				workspace.removeResourceChangeListener(changeReviewer);
+				changeReviewer = null;
+			}
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * 
+	 * @see org.eclipse.ui.plugin.AbstractUIPlugin#stop(org.osgi.framework.
+	 * BundleContext )
+	 */
+	public void stop(BundleContext context) throws Exception {
+
+		fileChangeListenerEnabled(false);
+
+		plugin = null;
+		disposeResources();
+		ShapePainter.disposeAll();
+		ResourceManager.dispose();
+		super.stop(context);
+	}
+
+	/**
+	 * Returns the shared instance
+	 *
+	 * @return the shared instance
+	 */
+	public static PMDPlugin getDefault() {
+		return plugin;
+	}
+
+	/**
+	 * Returns an image descriptor for the image file at the given plug-in relative
+	 * path.
+	 *
+	 * @param path
+	 *            the path
+	 * @return the image descriptor
+	 */
+	public static ImageDescriptor getImageDescriptor(String path) {
+		return AbstractUIPlugin.imageDescriptorFromPlugin("net.sourceforge.pmd.eclipse.plugin", path);
+	}
+
+	/**
+	 * Get an image corresponding to the severity
+	 */
+	public Image getImage(String key, String iconPath) {
+		ImageRegistry registry = getImageRegistry();
+		Image image = registry.get(key);
+		if (image == null) {
+			ImageDescriptor descriptor = getImageDescriptor(iconPath);
+			if (descriptor != null) {
+				registry.put(key, descriptor);
+				image = registry.get(key);
+			}
+		}
+
+		return image;
+	}
+
+	/**
+	 * Helper method to log error
+	 *
+	 * @see IStatus
+	 */
+	public void logError(String message, Throwable t) {
+		getLog().log(new Status(IStatus.ERROR, getBundle().getSymbolicName(), 0, message + t.getMessage(), t));
+		if (LOG != null) {
+			LOG.error(message, t);
+		}
+	}
+
+	/**
+	 * Helper method to log error
+	 *
+	 * @see IStatus
+	 */
+	public void logError(IStatus status) {
+		getLog().log(status);
+		if (LOG != null) {
+			LOG.error(status.getMessage(), status.getException());
+		}
+	}
+
+	/**
+	 * Helper method to display error
+	 */
+	public void showError(final String message, final Throwable t) {
+		logError(message, t);
+		Display.getDefault().syncExec(new Runnable() {
+
+			public void run() {
+				String errTitle = getStringTable().getString(StringKeys.ERROR_TITLE);
+				MessageDialog.openError(Display.getCurrent().getActiveShell(), errTitle,
+						message + "\n" + String.valueOf(t));
+			}
+		});
+	}
+
+	/**
+	 * Helper method to display a non-logged user error
+	 */
+	public void showUserError(final String message) {
+
+		Display.getDefault().syncExec(new Runnable() {
+
+			public void run() {
+				String errTitle = getStringTable().getString(StringKeys.ERROR_TITLE);
+				MessageDialog.openError(Display.getCurrent().getActiveShell(), errTitle, message);
+			}
+		});
+	}
+
+	/**
+	 * @return an instance of the string table
+	 */
+	public StringTable getStringTable() {
+		if (stringTable == null) {
+			stringTable = new StringTable();
+		}
+
+		return stringTable;
+	}
+
+	/**
+	 * @return the priority values
+	 * @deprecated
+	 */
+	public Integer[] getPriorityValues() {
+		return PRIORITY_VALUES;
+	}
+
+	/**
+	 * Load the PMD plugin preferences
+	 */
+	public IPreferences loadPreferences() {
+		return getPreferencesManager().loadPreferences();
+	}
+
+	/**
+	 * @return the plugin preferences manager
+	 */
+	public IPreferencesManager getPreferencesManager() {
+		return preferencesFactory.getPreferencesManager();
+	}
+
+	/**
+	 * @return the plugin project properties manager
+	 */
+	public IProjectPropertiesManager getPropertiesManager() {
+		return propertiesFactory.getProjectPropertiesManager();
+	}
+
+	/**
+	 * @param project
+	 *            a workspace project
+	 * @return the PMD properties for that project
+	 */
+	public IProjectProperties loadProjectProperties(IProject project) throws PropertiesException {
+		return getPropertiesManager().loadProjectProperties(project);
+	}
+
+	/**
+	 * Helper method to log information
+	 *
+	 * @see IStatus
+	 */
+	public void logInformation(String message) {
+		getLog().log(new Status(IStatus.INFO, getBundle().getSymbolicName(), 0, message, null));
+	}
+
+	public void logWarn(String message) {
+		getLog().log(new Status(IStatus.WARNING, getBundle().getSymbolicName(), 0, message, null));
+	}
+
+	/**
+	 * @return an instance of an AST writer
+	 */
+	public IAstWriter getAstWriter() {
+		return new WriterFactoryImpl().getAstWriter();
+	}
+
+	/**
+	 * @return an instance of a ruleset writer
+	 */
+	public IRuleSetWriter getRuleSetWriter() {
+		return new WriterFactoryImpl().getRuleSetWriter();
+	}
+
+	/**
+	 * Apply the log preferences
+	 */
+	public void applyLogPreferences(IPreferences preferences) {
+		Logger log = Logger.getLogger(ROOT_LOG_ID);
+		log.setLevel(preferences.getLogLevel());
+		RollingFileAppender appender = (RollingFileAppender) log.getAppender(PMD_ECLIPSE_APPENDER_NAME);
+		if (appender == null) {
+			configureLogs(preferences);
+		} else if (!appender.getFile().equals(preferences.getLogFileName())) {
+			appender.setFile(preferences.getLogFileName());
+			appender.activateOptions();
+		}
+	}
+
+	/**
+	 * Configure the logging
+	 *
+	 */
+	private void configureLogs(IPreferences preferences) {
+		try {
+			Layout layout = new PatternLayout("%d{yyyy/MM/dd HH:mm:ss,SSS} %-5p %-32c{1} %m%n");
+
+			RollingFileAppender appender = new RollingFileAppender(layout, preferences.getLogFileName());
+			appender.setName(PMD_ECLIPSE_APPENDER_NAME);
+			appender.setMaxBackupIndex(1);
+			appender.setMaxFileSize("10MB");
+
+			Logger.getRootLogger().addAppender(new ConsoleAppender(layout));
+			Logger.getRootLogger().setLevel(Level.WARN);
+			Logger.getRootLogger().setAdditivity(false);
+
+			Logger.getLogger(ROOT_LOG_ID).addAppender(appender);
+			Logger.getLogger(ROOT_LOG_ID).setLevel(preferences.getLogLevel());
+			Logger.getLogger(ROOT_LOG_ID).setAdditivity(false);
+
+		} catch (IOException e) {
+			logError("IO Exception when configuring logging.", e);
+		}
+	}
+
+	/**
+	 * @return the ruleset manager instance
+	 */
+	public final IRuleSetManager getRuleSetManager() {
+		return ruleSetManager;
+	}
+
+	/**
+	 * Logs inside the Eclipse environment
+	 *
+	 * @param severity
+	 *            the severity of the log (IStatus code)
+	 * @param message
+	 *            the message to log
+	 * @param t
+	 *            a possible throwable, may be null
+	 */
+	public final void log(final int severity, final String message, final Throwable t) {
+		final Bundle bundle = getBundle();
+		if (bundle != null) {
+			getLog().log(new Status(severity, bundle.getSymbolicName(), 0, message, t));
+		}
+
+		// TODO : when bundle is not created yet (ie at startup), we cannot log
+		// ; find a way to log.
+	}
+
+	/**
+	 * Registering the standard rulesets
+	 *
+	 */
+	private void registerStandardRuleSets() {
+
+		final RuleSetFactory factory = new RuleSetFactory();
+		try {
+			Iterator<RuleSet> iterator = factory.getRegisteredRuleSets();
+			final IRuleSetManager manager = getRuleSetManager();
+			RuleSet ruleSet;
+			while (iterator.hasNext()) {
+				ruleSet = iterator.next();
+				manager.registerRuleSet(ruleSet);
+				manager.registerDefaultRuleSet(ruleSet);
+			}
+		} catch (RuleSetNotFoundException e) {
+			log(IStatus.WARNING, "Problem getting all registered PMD RuleSets", e);
+		}
+	}
+
+	/**
+	 * Register additional rulesets that may be provided by a fragment. Find
+	 * extension points implementation and call them
+	 *
+	 */
+	private void registerAdditionalRuleSets() {
+		try {
+			final RuleSetsExtensionProcessor processor = new RuleSetsExtensionProcessor(getRuleSetManager());
+			processor.process();
+		} catch (CoreException e) {
+			log(IStatus.ERROR, "Error when processing RuleSets extensions", e);
+		}
+	}
+
+	public RuleLabelDecorator ruleLabelDecorator() {
+		IDecoratorManager mgr = getWorkbench().getDecoratorManager();
+		// TODO don't use a raw string...urgh
+		return (RuleLabelDecorator) mgr.getBaseLabelProvider("net.sourceforge.pmd.eclipse.plugin.RuleLabelDecorator");
+	}
+
+	public void changedFiles(Collection<IFile> changedFiles) {
+
+		RuleLabelDecorator rld = ruleLabelDecorator();
+		if (rld == null) {
+			return;
+		}
+
+		Collection<IResource> withParents = new HashSet<IResource>(changedFiles.size() * 2);
+		withParents.addAll(changedFiles);
+		for (IFile file : changedFiles) {
+			IResource parent = file.getParent();
+			while (parent != null) {
+				withParents.add(parent);
+				parent = parent.getParent();
+			}
+		}
+
+		rld.changed(withParents);
+	}
+
+	private void addFilesTo(IResource resource, Collection<IResource> allKids) {
+
+		if (resource instanceof IFile) {
+			allKids.add(resource);
+			return;
+		}
+
+		if (resource instanceof IFolder) {
+			IFolder folder = (IFolder) resource;
+			IResource[] kids = null;
+			try {
+				kids = folder.members();
+			} catch (CoreException e) {
+				e.printStackTrace();
+			}
+			addKids(allKids, kids);
+
+			allKids.add(folder);
+			return;
+		}
+
+		if (resource instanceof IProject) {
+			IProject project = (IProject) resource;
+			IResource[] kids = null;
+			try {
+				kids = project.members();
+			} catch (CoreException e) {
+				e.printStackTrace();
+			}
+			addKids(allKids, kids);
+			allKids.add(project);
+			return;
+		}
+	}
+
+	private void addKids(Collection<IResource> allKids, IResource[] kids) {
+
+		if (kids == null) {
+			return;
+		}
+
+		for (IResource irc : kids) {
+			if (irc instanceof IFile) {
+				allKids.add(irc);
+				continue;
+			}
+			if (irc instanceof IFolder) {
+				addFilesTo(irc, allKids);
+			}
+		}
+	}
+
+	public void removedMarkersIn(IResource resource) {
+
+		RuleLabelDecorator decorator = ruleLabelDecorator();
+		if (decorator == null) {
+			return;
+		}
+
+		Collection<IResource> changes = new ArrayList<IResource>();
+
+		addFilesTo(resource, changes);
+
+		decorator.changed(changes);
+	}
 
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
@@ -86,594 +86,592 @@ import net.sourceforge.pmd.util.datasource.ReaderDataSource;
  *
  */
 public class BaseVisitor {
-    private static final Logger LOG = Logger.getLogger(BaseVisitor.class);
-    private IProgressMonitor monitor;
-    private boolean useTaskMarker = false;
-    private Map<IFile, Set<MarkerInfo2>> accumulator;
-    // private PMDEngine pmdEngine;
-    private RuleSet ruleSet;
-    private int fileCount;
-    private long pmdDuration;
-    private IProjectProperties projectProperties;
-
-    private PMDConfiguration configuration;
-
-    /**
-     * The constructor is protected to avoid illegal instantiation
-     *
-     */
-    protected BaseVisitor() {
-        super();
-    }
-
-    protected PMDConfiguration configuration() {
-        if (configuration == null) {
-            configuration = new PMDConfiguration();
-        }
-        return configuration;
-    }
-
-    /**
-     * Returns the useTaskMarker.
-     *
-     * @return boolean
-     */
-    public boolean isUseTaskMarker() {
-        return useTaskMarker;
-    }
-
-    /**
-     * Sets the useTaskMarker.
-     *
-     * @param useTaskMarker
-     *            The useTaskMarker to set
-     */
-    public void setUseTaskMarker(final boolean useTaskMarker) {
-        this.useTaskMarker = useTaskMarker;
-    }
-
-    /**
-     * Returns the accumulator.
-     *
-     * @return Map
-     */
-    public Map<IFile, Set<MarkerInfo2>> getAccumulator() {
-        return accumulator;
-    }
-
-    /**
-     * Sets the accumulator.
-     *
-     * @param accumulator
-     *            The accumulator to set
-     */
-    public void setAccumulator(final Map<IFile, Set<MarkerInfo2>> accumulator) {
-        this.accumulator = accumulator;
-    }
-
-    /**
-     * @return
-     */
-    public IProgressMonitor getMonitor() {
-        return monitor;
-    }
-
-    /**
-     * @param monitor
-     */
-    public void setMonitor(final IProgressMonitor monitor) {
-        this.monitor = monitor;
-    }
-
-    /**
-     * Tell whether the user has required to cancel the operation
-     *
-     * @return
-     */
-    public boolean isCanceled() {
-        return getMonitor() == null ? false : getMonitor().isCanceled();
-    }
-
-    /**
-     * Begin a subtask
-     *
-     * @param name
-     *            the task name
-     */
-    public void subTask(final String name) {
-        if (getMonitor() != null) {
-            getMonitor().subTask(name);
-        }
-    }
-
-    /**
-     * Inform of the work progress
-     *
-     * @param work
-     */
-    public void worked(final int work) {
-        if (getMonitor() != null) {
-            getMonitor().worked(work);
-        }
-    }
-
-    // /**
-    // * @return Returns the pmdEngine.
-    // */
-    // public PMDEngine getPmdEngine() {
-    // return pmdEngine;
-    // }
-    //
-    // /**
-    // * @param pmdEngine
-    // * The pmdEngine to set.
-    // */
-    // public void setPmdEngine(final PMDEngine pmdEngine) {
-    // this.pmdEngine = pmdEngine;
-    // }
-
-    /**
-     * @return Returns the ruleSet.
-     */
-    public RuleSet getRuleSet() {
-        return this.ruleSet;
-    }
-
-    /**
-     * @param ruleSet
-     *            The ruleSet to set.
-     */
-    public void setRuleSet(final RuleSet ruleSet) {
-        this.ruleSet = ruleSet;
-    }
-
-    /**
-     * @return the number of files that has been processed
-     */
-    public int getProcessedFilesCount() {
-        return fileCount;
-    }
-
-    /**
-     * @return actual PMD duration
-     */
-    public long getActualPmdDuration() {
-        return pmdDuration;
-    }
-
-    /**
-     * Set the project properties (note that visitor is expected to be called
-     * one project at a time
-     */
-    public void setProjectProperties(IProjectProperties projectProperties) {
-        this.projectProperties = projectProperties;
-    }
-
-    private boolean isIncluded(IFile file) throws PropertiesException {
-        return projectProperties.isIncludeDerivedFiles()
-                || !projectProperties.isIncludeDerivedFiles() && !file.isDerived();
-    }
-
-    /**
-     * Run PMD against a resource
-     *
-     * @param resource
-     *            the resource to process
-     */
-    protected final void reviewResource(IResource resource) {
-
-        IFile file = (IFile) resource.getAdapter(IFile.class);
-        if (file == null || file.getFileExtension() == null) {
-            return;
-        }
-
-        Reader input = null;
-        try {
-            boolean included = isIncluded(file);
-            LOG.debug("Derived files included: " + projectProperties.isIncludeDerivedFiles());
-            LOG.debug("file " + file.getName() + " is derived: " + file.isDerived());
-            LOG.debug("file checked: " + included);
-
-            prepareMarkerAccumulator(file);
-
-            LanguageVersionDiscoverer languageDiscoverer = new LanguageVersionDiscoverer();
-            LanguageVersion languageVersion = languageDiscoverer.getDefaultLanguageVersionForFile(file.getName());
-            // in case it is java, select the correct java version
-            if (languageVersion != null
-                    && languageVersion.getLanguage() == LanguageRegistry.getLanguage(JavaLanguageModule.NAME)) {
-                languageVersion = PMDPlugin.javaVersionFor(file.getProject());
-            }
-            if (languageVersion != null) {
-                configuration().setDefaultLanguageVersion(languageVersion);
-            }
-            LOG.debug("discovered language: " + languageVersion);
-
-            PMDPlugin.setJavaClassLoader(configuration(), resource.getProject());
-
-            final File sourceCodeFile = file.getRawLocation().toFile();
-            if (included && getRuleSet().applies(sourceCodeFile) && isFileInWorkingSet(file)
-                    && languageVersion != null) {
-                subTask("PMD checking: " + file.getName());
-
-                Timer timer = new Timer();
-
-                RuleContext context = PMD.newRuleContext(file.getName(), sourceCodeFile);
-                context.setLanguageVersion(languageVersion);
-
-                input = new InputStreamReader(file.getContents(), file.getCharset());
-                // getPmdEngine().processFile(input, getRuleSet(), context);
-                // getPmdEngine().processFile(sourceCodeFile, getRuleSet(),
-                // context);
-
-                DataSource dataSource = new ReaderDataSource(input, file.getName());
-                RuleSetFactory ruleSetFactory = new RuleSetFactory() {
-                    @Override
-                    public synchronized RuleSets createRuleSets(String referenceString)
-                            throws RuleSetNotFoundException {
-                        return new RuleSets(getRuleSet());
-                    }
-                };
-                // need to disable multi threading, as the ruleset is
-                // not recreated and shared between threads...
-                // but as we anyway have only one file to process, it won't hurt
-                // here.
-                configuration().setThreads(0);
-                LOG.debug("PMD running on file " + file.getName());
-                final Report collectingReport = new Report();
-                Renderer collectingRenderer = new AbstractRenderer("collectingRenderer",
-                        "Renderer that collect violations") {
-                    @Override
-                    public void startFileAnalysis(DataSource dataSource) {
-                        // TODO Auto-generated method stub
-
-                    }
-
-                    @Override
-                    public void start() throws IOException {
-                        // TODO Auto-generated method stub
-
-                    }
-
-                    @Override
-                    public void renderFileReport(Report report) throws IOException {
-                        for (RuleViolation v : report) {
-                            collectingReport.addRuleViolation(v);
-                        }
-                        for (Iterator<ProcessingError> it = report.errors(); it.hasNext();) {
-                            collectingReport.addError(it.next());
-                        }
-                        for (Iterator<ConfigurationError> it = report.configErrors(); it.hasNext();) {
-                            collectingReport.addConfigError(it.next());
-                        }
-                    }
-
-                    @Override
-                    public void end() throws IOException {
-                        // TODO Auto-generated method stub
-
-                    }
-
-                    @Override
-                    public String defaultFileExtension() {
-                        // TODO Auto-generated method stub
-                        return null;
-                    }
-                };
-
-                // PMD.processFiles(configuration(), ruleSetFactory,
-                // Arrays.asList(dataSource), context,
-                // Arrays.asList(collectingRenderer));
-                new MonoThreadProcessor(configuration()).processFiles(ruleSetFactory, Arrays.asList(dataSource),
-                        context, Arrays.asList(collectingRenderer));
-                LOG.debug("PMD run finished.");
-
-                timer.stop();
-                pmdDuration += timer.getDuration();
-
-                LOG.debug("PMD found " + collectingReport.size() + " violations for file " + file.getName());
-
-                if (collectingReport.hasErrors()) {
-                    StringBuilder message = new StringBuilder("There were processing errors!\n");
-                    Iterator<ProcessingError> errors = context.getReport().errors();
-                    while (errors.hasNext()) {
-                        ProcessingError error = errors.next();
-                        message.append(error.getFile()).append(": ").append(error.getMsg()).append("\n");
-                    }
-                    PMDPlugin.getDefault().logWarn(message.toString());
-                    throw new PMDException(message.toString());
-                }
-
-                updateMarkers(file, collectingReport.iterator(), isUseTaskMarker());
-
-                worked(1);
-                fileCount++;
-            } else {
-                LOG.debug("The file " + file.getName() + " is not in the working set");
-            }
-
-        } catch (CoreException e) {
-            // TODO: complete message
-            LOG.error("Core exception visiting " + file.getName(), e); 
-        } catch (PMDException e) {
-            // TODO: complete message
-            LOG.error("PMD exception visiting " + file.getName(), e);
-        } catch (IOException e) {
-            // TODO: complete message
-            LOG.error("IO exception visiting " + file.getName(), e);
-        } catch (PropertiesException e) {
-            // TODO: complete message
-            LOG.error("Properties exception visiting " + file.getName(), e);
-        } catch (IllegalArgumentException e) {
-            LOG.error("Illegal argument", e);
-        } finally {
-            IOUtil.closeQuietly(input);
-        }
-
-    }
-
-    /**
-     * Test if a file is in the PMD working set
-     *
-     * @param file
-     * @return true if the file should be checked
-     */
-    private boolean isFileInWorkingSet(final IFile file) throws PropertiesException {
-        boolean fileInWorkingSet = true;
-        IWorkingSet workingSet = projectProperties.getProjectWorkingSet();
-        if (workingSet != null) {
-            ResourceWorkingSetFilter filter = new ResourceWorkingSetFilter();
-            filter.setWorkingSet(workingSet);
-            fileInWorkingSet = filter.select(null, null, file);
-        }
-
-        return fileInWorkingSet;
-    }
-
-    /**
-     * Update markers list for the specified file
-     *
-     * @param file
-     *            the file for which markers are to be updated
-     * @param context
-     *            a PMD context
-     * @param fTask
-     *            indicate if a task marker should be created
-     * @param accumulator
-     *            a map that contains impacted file and marker informations
-     */
-
-    private int maxAllowableViolationsFor(Rule rule) {
-
-        return rule.hasDescriptor(PMDRuntimeConstants.MAX_VIOLATIONS_DESCRIPTOR)
-                ? rule.getProperty(PMDRuntimeConstants.MAX_VIOLATIONS_DESCRIPTOR)
-                : PMDRuntimeConstants.MAX_VIOLATIONS_DESCRIPTOR.defaultValue();
-    }
-
-    public static String markerTypeFor(RuleViolation violation) {
-
-        int priorityId = violation.getRule().getPriority().getPriority();
-
-        switch (priorityId) {
-        case 1:
-            return PMDRuntimeConstants.PMD_MARKER_1;
-        case 2:
-            return PMDRuntimeConstants.PMD_MARKER_2;
-        case 3:
-            return PMDRuntimeConstants.PMD_MARKER_3;
-        case 4:
-            return PMDRuntimeConstants.PMD_MARKER_4;
-        case 5:
-            return PMDRuntimeConstants.PMD_MARKER_5;
-        default:
-            return PMDRuntimeConstants.PMD_MARKER;
-        }
-    }
-
-    private void prepareMarkerAccumulator(IFile file) {
-        Map<IFile, Set<MarkerInfo2>> accumulator = getAccumulator();
-        if (accumulator != null) {
-            accumulator.put(file, new HashSet<MarkerInfo2>());
-        }
-    }
-
-    private void updateMarkers(IFile file, Iterator<RuleViolation> violations, boolean fTask)
-            throws CoreException, PropertiesException {
-
-        Map<IFile, Set<MarkerInfo2>> accumulator = getAccumulator();
-        Set<MarkerInfo2> markerSet = new HashSet<MarkerInfo2>();
-        List<Review> reviewsList = findReviewedViolations(file);
-        Review review = new Review();
-        // final IPreferences preferences =
-        // PMDPlugin.getDefault().loadPreferences();
-        // final int maxViolationsPerFilePerRule =
-        // preferences.getMaxViolationsPerFilePerRule();
-        Map<Rule, Integer> violationsByRule = new HashMap<Rule, Integer>();
-
-        Rule rule;
-        while (violations.hasNext()) {
-            RuleViolation violation = violations.next();
-            rule = violation.getRule();
-            review.ruleName = rule.getName();
-            review.lineNumber = violation.getBeginLine();
-
-            /* Only show active violations */
-            if(!PriorityUtil.getActivePriorites().contains(rule.getPriority())) {
-            	continue;
-            }
-            
-            if (reviewsList.contains(review)) {
-                LOG.debug("Ignoring violation of rule " + rule.getName() + " at line " + violation.getBeginLine()
-                        + " because of a review.");
-                continue;
-            }
-
-            Integer count = violationsByRule.get(rule);
-            if (count == null) {
-                count = NumericConstants.ZERO;
-                violationsByRule.put(rule, count);
-            }
-
-            int maxViolations = maxAllowableViolationsFor(rule);
-
-            if (count.intValue() < maxViolations) {
-                // Ryan Gustafson 02/16/2008 - Always use PMD_MARKER, as people
-                // get confused as to why PMD problems don't always show up on
-                // Problems view like they do when you do build.
-                // markerSet.add(getMarkerInfo(violation, fTask ?
-                // PMDRuntimeConstants.PMD_TASKMARKER :
-                // PMDRuntimeConstants.PMD_MARKER));
-                markerSet.add(getMarkerInfo(violation, markerTypeFor(violation)));
-                /*
-                 * if (isDfaEnabled && violation.getRule().usesDFA()) {
-                 * markerSet.add(getMarkerInfo(violation,
-                 * PMDRuntimeConstants.PMD_DFA_MARKER)); } else {
-                 * markerSet.add(getMarkerInfo(violation, fTask ?
-                 * PMDRuntimeConstants.PMD_TASKMARKER :
-                 * PMDRuntimeConstants.PMD_MARKER)); }
-                 */
-                violationsByRule.put(rule, Integer.valueOf(count.intValue() + 1));
-
-                LOG.debug("Adding a violation for rule " + rule.getName() + " at line " + violation.getBeginLine());
-            } else {
-                LOG.debug("Ignoring violation of rule " + rule.getName() + " at line " + violation.getBeginLine()
-                        + " because maximum violations has been reached for file " + file.getName());
-            }
-        }
-
-        if (accumulator != null) {
-            LOG.debug("Adding markerSet to accumulator for file " + file.getName());
-            accumulator.put(file, markerSet);
-        }
-    }
-
-    /**
-     * Search for reviewed violations in that file
-     *
-     * @param file
-     */
-    private List<Review> findReviewedViolations(final IFile file) {
-        final List<Review> reviews = new ArrayList<Review>();
-        BufferedReader reader = null;
-        try {
-            int lineNumber = 0;
-            boolean findLine = false;
-            boolean comment = false;
-            final Stack<String> pendingReviews = new Stack<String>();
-            reader = new BufferedReader(new InputStreamReader(file.getContents()));
-            while (reader.ready()) {
-                String line = reader.readLine();
-                if (line != null) {
-                    line = line.trim();
-                    lineNumber++;
-                    if (line.startsWith("/*")) {
-                        comment = line.indexOf("*/") == -1;
-                    } else if (comment && line.indexOf("*/") != -1) {
-                        comment = false;
-                    } else if (!comment && line.startsWith(PMDRuntimeConstants.PLUGIN_STYLE_REVIEW_COMMENT)) {
-                        final String tail = line.substring(PMDRuntimeConstants.PLUGIN_STYLE_REVIEW_COMMENT.length());
-                        final String ruleName = tail.substring(0, tail.indexOf(':'));
-                        pendingReviews.push(ruleName);
-                        findLine = true;
-                    } else if (!comment && findLine && StringUtil.isNotEmpty(line) && !line.startsWith("//")) {
-                        findLine = false;
-                        while (!pendingReviews.empty()) {
-                            // @PMD:REVIEWED:AvoidInstantiatingObjectsInLoops:
-                            // by Herlin on 01/05/05 18:36
-                            final Review review = new Review();
-                            review.ruleName = pendingReviews.pop();
-                            review.lineNumber = lineNumber;
-                            reviews.add(review);
-                        }
-                    }
-                }
-            }
-
-            // if (log.isDebugEnabled()) {
-            // for (int i = 0; i < reviewsList.size(); i++) {
-            // final Review review = (Review) reviewsList.get(i);
-            // log.debug("Review : rule " + review.ruleName + ", line " +
-            // review.lineNumber);
-            // }
-            // }
-
-        } catch (CoreException e) {
-            PMDPlugin.getDefault().logError("Core Exception when searching reviewed violations", e);
-        } catch (IOException e) {
-            PMDPlugin.getDefault().logError("IO Exception when searching reviewed violations", e);
-        } finally {
-            IOUtil.closeQuietly(reader);
-        }
-
-        return reviews;
-    }
-
-    private MarkerInfo2 getMarkerInfo(RuleViolation violation, String type) throws PropertiesException {
-
-        Rule rule = violation.getRule();
-
-        MarkerInfo2 info = new MarkerInfo2(type, 7);
-
-        info.add(IMarker.MESSAGE, violation.getDescription());
-        info.add(IMarker.LINE_NUMBER, violation.getBeginLine());
-        info.add(PMDRuntimeConstants.KEY_MARKERATT_LINE2, violation.getEndLine());
-        info.add(PMDRuntimeConstants.KEY_MARKERATT_RULENAME, rule.getName());
-        info.add(PMDRuntimeConstants.KEY_MARKERATT_PRIORITY, rule.getPriority().getPriority());
-
-        switch (rule.getPriority().getPriority()) {
-        case 1:
-            info.add(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
-            info.add(IMarker.SEVERITY,
-                    projectProperties.violationsAsErrors() ? IMarker.SEVERITY_ERROR : IMarker.SEVERITY_WARNING);
-            break;
-        case 2:
-            if (projectProperties.violationsAsErrors()) {
-                info.add(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
-            } else {
-                info.add(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
-                info.add(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
-            }
-            break;
-
-        case 5:
-            info.add(IMarker.SEVERITY, IMarker.SEVERITY_INFO);
-            break;
-
-        case 3:
-            info.add(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
-            info.add(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
-            break;
-
-        case 4:
-        default:
-            info.add(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
-            info.add(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
-            break;
-        }
-
-        return info;
-    }
-
-    /**
-     * Private inner type to handle reviews
-     */
-    private class Review {
-        public String ruleName;
-        public int lineNumber;
-
-        @Override
-        public boolean equals(final Object obj) {
-            boolean result = false;
-            if (obj instanceof Review) {
-                Review reviewObj = (Review) obj;
-                result = ruleName.equals(reviewObj.ruleName) && lineNumber == reviewObj.lineNumber;
-            }
-            return result;
-        }
-
-        @Override
-        public int hashCode() {
-            return ruleName.hashCode() + lineNumber * lineNumber;
-        }
-
-    }
+	private static final Logger LOG = Logger.getLogger(BaseVisitor.class);
+	private IProgressMonitor monitor;
+	private boolean useTaskMarker = false;
+	private Map<IFile, Set<MarkerInfo2>> accumulator;
+	// private PMDEngine pmdEngine;
+	private RuleSet ruleSet;
+	private int fileCount;
+	private long pmdDuration;
+	private IProjectProperties projectProperties;
+
+	private PMDConfiguration configuration;
+
+	/**
+	 * The constructor is protected to avoid illegal instantiation
+	 *
+	 */
+	protected BaseVisitor() {
+		super();
+	}
+
+	protected PMDConfiguration configuration() {
+		if (configuration == null) {
+			configuration = new PMDConfiguration();
+		}
+		return configuration;
+	}
+
+	/**
+	 * Returns the useTaskMarker.
+	 *
+	 * @return boolean
+	 */
+	public boolean isUseTaskMarker() {
+		return useTaskMarker;
+	}
+
+	/**
+	 * Sets the useTaskMarker.
+	 *
+	 * @param useTaskMarker
+	 *            The useTaskMarker to set
+	 */
+	public void setUseTaskMarker(final boolean useTaskMarker) {
+		this.useTaskMarker = useTaskMarker;
+	}
+
+	/**
+	 * Returns the accumulator.
+	 *
+	 * @return Map
+	 */
+	public Map<IFile, Set<MarkerInfo2>> getAccumulator() {
+		return accumulator;
+	}
+
+	/**
+	 * Sets the accumulator.
+	 *
+	 * @param accumulator
+	 *            The accumulator to set
+	 */
+	public void setAccumulator(final Map<IFile, Set<MarkerInfo2>> accumulator) {
+		this.accumulator = accumulator;
+	}
+
+	/**
+	 * @return
+	 */
+	public IProgressMonitor getMonitor() {
+		return monitor;
+	}
+
+	/**
+	 * @param monitor
+	 */
+	public void setMonitor(final IProgressMonitor monitor) {
+		this.monitor = monitor;
+	}
+
+	/**
+	 * Tell whether the user has required to cancel the operation
+	 *
+	 * @return
+	 */
+	public boolean isCanceled() {
+		return getMonitor() == null ? false : getMonitor().isCanceled();
+	}
+
+	/**
+	 * Begin a subtask
+	 *
+	 * @param name
+	 *            the task name
+	 */
+	public void subTask(final String name) {
+		if (getMonitor() != null) {
+			getMonitor().subTask(name);
+		}
+	}
+
+	/**
+	 * Inform of the work progress
+	 *
+	 * @param work
+	 */
+	public void worked(final int work) {
+		if (getMonitor() != null) {
+			getMonitor().worked(work);
+		}
+	}
+
+	// /**
+	// * @return Returns the pmdEngine.
+	// */
+	// public PMDEngine getPmdEngine() {
+	// return pmdEngine;
+	// }
+	//
+	// /**
+	// * @param pmdEngine
+	// * The pmdEngine to set.
+	// */
+	// public void setPmdEngine(final PMDEngine pmdEngine) {
+	// this.pmdEngine = pmdEngine;
+	// }
+
+	/**
+	 * @return Returns the ruleSet.
+	 */
+	public RuleSet getRuleSet() {
+		return this.ruleSet;
+	}
+
+	/**
+	 * @param ruleSet
+	 *            The ruleSet to set.
+	 */
+	public void setRuleSet(final RuleSet ruleSet) {
+		this.ruleSet = ruleSet;
+	}
+
+	/**
+	 * @return the number of files that has been processed
+	 */
+	public int getProcessedFilesCount() {
+		return fileCount;
+	}
+
+	/**
+	 * @return actual PMD duration
+	 */
+	public long getActualPmdDuration() {
+		return pmdDuration;
+	}
+
+	/**
+	 * Set the project properties (note that visitor is expected to be called one
+	 * project at a time
+	 */
+	public void setProjectProperties(IProjectProperties projectProperties) {
+		this.projectProperties = projectProperties;
+	}
+
+	private boolean isIncluded(IFile file) throws PropertiesException {
+		return projectProperties.isIncludeDerivedFiles()
+				|| !projectProperties.isIncludeDerivedFiles() && !file.isDerived();
+	}
+
+	/**
+	 * Run PMD against a resource
+	 *
+	 * @param resource
+	 *            the resource to process
+	 */
+	protected final void reviewResource(IResource resource) {
+
+		IFile file = (IFile) resource.getAdapter(IFile.class);
+		if (file == null || file.getFileExtension() == null) {
+			return;
+		}
+
+		Reader input = null;
+		try {
+			boolean included = isIncluded(file);
+			LOG.debug("Derived files included: " + projectProperties.isIncludeDerivedFiles());
+			LOG.debug("file " + file.getName() + " is derived: " + file.isDerived());
+			LOG.debug("file checked: " + included);
+
+			prepareMarkerAccumulator(file);
+
+			LanguageVersionDiscoverer languageDiscoverer = new LanguageVersionDiscoverer();
+			LanguageVersion languageVersion = languageDiscoverer.getDefaultLanguageVersionForFile(file.getName());
+			// in case it is java, select the correct java version
+			if (languageVersion != null
+					&& languageVersion.getLanguage() == LanguageRegistry.getLanguage(JavaLanguageModule.NAME)) {
+				languageVersion = PMDPlugin.javaVersionFor(file.getProject());
+			}
+			if (languageVersion != null) {
+				configuration().setDefaultLanguageVersion(languageVersion);
+			}
+			LOG.debug("discovered language: " + languageVersion);
+
+			PMDPlugin.setJavaClassLoader(configuration(), resource.getProject());
+
+			final File sourceCodeFile = file.getRawLocation().toFile();
+			if (included && getRuleSet().applies(sourceCodeFile) && isFileInWorkingSet(file)
+					&& languageVersion != null) {
+				subTask("PMD checking: " + file.getName());
+
+				Timer timer = new Timer();
+
+				RuleContext context = PMD.newRuleContext(file.getName(), sourceCodeFile);
+				context.setLanguageVersion(languageVersion);
+
+				input = new InputStreamReader(file.getContents(), file.getCharset());
+				// getPmdEngine().processFile(input, getRuleSet(), context);
+				// getPmdEngine().processFile(sourceCodeFile, getRuleSet(),
+				// context);
+
+				DataSource dataSource = new ReaderDataSource(input, file.getName());
+				RuleSetFactory ruleSetFactory = new RuleSetFactory() {
+					@Override
+					public synchronized RuleSets createRuleSets(String referenceString)
+							throws RuleSetNotFoundException {
+						return new RuleSets(getRuleSet());
+					}
+				};
+				// need to disable multi threading, as the ruleset is
+				// not recreated and shared between threads...
+				// but as we anyway have only one file to process, it won't hurt
+				// here.
+				configuration().setThreads(0);
+				LOG.debug("PMD running on file " + file.getName());
+				final Report collectingReport = new Report();
+				Renderer collectingRenderer = new AbstractRenderer("collectingRenderer",
+						"Renderer that collect violations") {
+					@Override
+					public void startFileAnalysis(DataSource dataSource) {
+						// TODO Auto-generated method stub
+
+					}
+
+					@Override
+					public void start() throws IOException {
+						// TODO Auto-generated method stub
+
+					}
+
+					@Override
+					public void renderFileReport(Report report) throws IOException {
+						for (RuleViolation v : report) {
+							collectingReport.addRuleViolation(v);
+						}
+						for (Iterator<ProcessingError> it = report.errors(); it.hasNext();) {
+							collectingReport.addError(it.next());
+						}
+						for (Iterator<ConfigurationError> it = report.configErrors(); it.hasNext();) {
+							collectingReport.addConfigError(it.next());
+						}
+					}
+
+					@Override
+					public void end() throws IOException {
+						// TODO Auto-generated method stub
+
+					}
+
+					@Override
+					public String defaultFileExtension() {
+						// TODO Auto-generated method stub
+						return null;
+					}
+				};
+
+				// PMD.processFiles(configuration(), ruleSetFactory,
+				// Arrays.asList(dataSource), context,
+				// Arrays.asList(collectingRenderer));
+				new MonoThreadProcessor(configuration()).processFiles(ruleSetFactory, Arrays.asList(dataSource),
+						context, Arrays.asList(collectingRenderer));
+				LOG.debug("PMD run finished.");
+
+				timer.stop();
+				pmdDuration += timer.getDuration();
+
+				LOG.debug("PMD found " + collectingReport.size() + " violations for file " + file.getName());
+
+				if (collectingReport.hasErrors()) {
+					StringBuilder message = new StringBuilder("There were processing errors!\n");
+					Iterator<ProcessingError> errors = context.getReport().errors();
+					while (errors.hasNext()) {
+						ProcessingError error = errors.next();
+						message.append(error.getFile()).append(": ").append(error.getMsg()).append("\n");
+					}
+					PMDPlugin.getDefault().logWarn(message.toString());
+					throw new PMDException(message.toString());
+				}
+
+				updateMarkers(file, collectingReport.iterator(), isUseTaskMarker());
+
+				worked(1);
+				fileCount++;
+			} else {
+				LOG.debug("The file " + file.getName() + " is not in the working set");
+			}
+
+		} catch (CoreException e) {
+			// TODO: complete message
+			LOG.error("Core exception visiting " + file.getName(), e);
+		} catch (PMDException e) {
+			// TODO: complete message
+			LOG.error("PMD exception visiting " + file.getName(), e);
+		} catch (IOException e) {
+			// TODO: complete message
+			LOG.error("IO exception visiting " + file.getName(), e);
+		} catch (PropertiesException e) {
+			// TODO: complete message
+			LOG.error("Properties exception visiting " + file.getName(), e);
+		} catch (IllegalArgumentException e) {
+			LOG.error("Illegal argument", e);
+		} finally {
+			IOUtil.closeQuietly(input);
+		}
+
+	}
+
+	/**
+	 * Test if a file is in the PMD working set
+	 *
+	 * @param file
+	 * @return true if the file should be checked
+	 */
+	private boolean isFileInWorkingSet(final IFile file) throws PropertiesException {
+		boolean fileInWorkingSet = true;
+		IWorkingSet workingSet = projectProperties.getProjectWorkingSet();
+		if (workingSet != null) {
+			ResourceWorkingSetFilter filter = new ResourceWorkingSetFilter();
+			filter.setWorkingSet(workingSet);
+			fileInWorkingSet = filter.select(null, null, file);
+		}
+
+		return fileInWorkingSet;
+	}
+
+	/**
+	 * Update markers list for the specified file
+	 *
+	 * @param file
+	 *            the file for which markers are to be updated
+	 * @param context
+	 *            a PMD context
+	 * @param fTask
+	 *            indicate if a task marker should be created
+	 * @param accumulator
+	 *            a map that contains impacted file and marker informations
+	 */
+
+	private int maxAllowableViolationsFor(Rule rule) {
+
+		return rule.hasDescriptor(PMDRuntimeConstants.MAX_VIOLATIONS_DESCRIPTOR)
+				? rule.getProperty(PMDRuntimeConstants.MAX_VIOLATIONS_DESCRIPTOR)
+				: PMDRuntimeConstants.MAX_VIOLATIONS_DESCRIPTOR.defaultValue();
+	}
+
+	public static String markerTypeFor(RuleViolation violation) {
+
+		int priorityId = violation.getRule().getPriority().getPriority();
+
+		switch (priorityId) {
+		case 1:
+			return PMDRuntimeConstants.PMD_MARKER_1;
+		case 2:
+			return PMDRuntimeConstants.PMD_MARKER_2;
+		case 3:
+			return PMDRuntimeConstants.PMD_MARKER_3;
+		case 4:
+			return PMDRuntimeConstants.PMD_MARKER_4;
+		case 5:
+			return PMDRuntimeConstants.PMD_MARKER_5;
+		default:
+			return PMDRuntimeConstants.PMD_MARKER;
+		}
+	}
+
+	private void prepareMarkerAccumulator(IFile file) {
+		Map<IFile, Set<MarkerInfo2>> accumulator = getAccumulator();
+		if (accumulator != null) {
+			accumulator.put(file, new HashSet<MarkerInfo2>());
+		}
+	}
+
+	private void updateMarkers(IFile file, Iterator<RuleViolation> violations, boolean fTask)
+			throws CoreException, PropertiesException {
+
+		Map<IFile, Set<MarkerInfo2>> accumulator = getAccumulator();
+		Set<MarkerInfo2> markerSet = new HashSet<MarkerInfo2>();
+		List<Review> reviewsList = findReviewedViolations(file);
+		Review review = new Review();
+		// final IPreferences preferences =
+		// PMDPlugin.getDefault().loadPreferences();
+		// final int maxViolationsPerFilePerRule =
+		// preferences.getMaxViolationsPerFilePerRule();
+		Map<Rule, Integer> violationsByRule = new HashMap<Rule, Integer>();
+
+		Rule rule;
+		while (violations.hasNext()) {
+			RuleViolation violation = violations.next();
+			rule = violation.getRule();
+			review.ruleName = rule.getName();
+			review.lineNumber = violation.getBeginLine();
+
+			/* Only show active violations */
+			if (!PriorityUtil.isPriorityActive(rule.getPriority())) {
+				continue;
+			}
+
+			if (reviewsList.contains(review)) {
+				LOG.debug("Ignoring violation of rule " + rule.getName() + " at line " + violation.getBeginLine()
+						+ " because of a review.");
+				continue;
+			}
+
+			Integer count = violationsByRule.get(rule);
+			if (count == null) {
+				count = NumericConstants.ZERO;
+				violationsByRule.put(rule, count);
+			}
+
+			int maxViolations = maxAllowableViolationsFor(rule);
+
+			if (count.intValue() < maxViolations) {
+				// Ryan Gustafson 02/16/2008 - Always use PMD_MARKER, as people
+				// get confused as to why PMD problems don't always show up on
+				// Problems view like they do when you do build.
+				// markerSet.add(getMarkerInfo(violation, fTask ?
+				// PMDRuntimeConstants.PMD_TASKMARKER :
+				// PMDRuntimeConstants.PMD_MARKER));
+				markerSet.add(getMarkerInfo(violation, markerTypeFor(violation)));
+				/*
+				 * if (isDfaEnabled && violation.getRule().usesDFA()) {
+				 * markerSet.add(getMarkerInfo(violation, PMDRuntimeConstants.PMD_DFA_MARKER));
+				 * } else { markerSet.add(getMarkerInfo(violation, fTask ?
+				 * PMDRuntimeConstants.PMD_TASKMARKER : PMDRuntimeConstants.PMD_MARKER)); }
+				 */
+				violationsByRule.put(rule, Integer.valueOf(count.intValue() + 1));
+
+				LOG.debug("Adding a violation for rule " + rule.getName() + " at line " + violation.getBeginLine());
+			} else {
+				LOG.debug("Ignoring violation of rule " + rule.getName() + " at line " + violation.getBeginLine()
+						+ " because maximum violations has been reached for file " + file.getName());
+			}
+		}
+
+		if (accumulator != null) {
+			LOG.debug("Adding markerSet to accumulator for file " + file.getName());
+			accumulator.put(file, markerSet);
+		}
+	}
+
+	/**
+	 * Search for reviewed violations in that file
+	 *
+	 * @param file
+	 */
+	private List<Review> findReviewedViolations(final IFile file) {
+		final List<Review> reviews = new ArrayList<Review>();
+		BufferedReader reader = null;
+		try {
+			int lineNumber = 0;
+			boolean findLine = false;
+			boolean comment = false;
+			final Stack<String> pendingReviews = new Stack<String>();
+			reader = new BufferedReader(new InputStreamReader(file.getContents()));
+			while (reader.ready()) {
+				String line = reader.readLine();
+				if (line != null) {
+					line = line.trim();
+					lineNumber++;
+					if (line.startsWith("/*")) {
+						comment = line.indexOf("*/") == -1;
+					} else if (comment && line.indexOf("*/") != -1) {
+						comment = false;
+					} else if (!comment && line.startsWith(PMDRuntimeConstants.PLUGIN_STYLE_REVIEW_COMMENT)) {
+						final String tail = line.substring(PMDRuntimeConstants.PLUGIN_STYLE_REVIEW_COMMENT.length());
+						final String ruleName = tail.substring(0, tail.indexOf(':'));
+						pendingReviews.push(ruleName);
+						findLine = true;
+					} else if (!comment && findLine && StringUtil.isNotEmpty(line) && !line.startsWith("//")) {
+						findLine = false;
+						while (!pendingReviews.empty()) {
+							// @PMD:REVIEWED:AvoidInstantiatingObjectsInLoops:
+							// by Herlin on 01/05/05 18:36
+							final Review review = new Review();
+							review.ruleName = pendingReviews.pop();
+							review.lineNumber = lineNumber;
+							reviews.add(review);
+						}
+					}
+				}
+			}
+
+			// if (log.isDebugEnabled()) {
+			// for (int i = 0; i < reviewsList.size(); i++) {
+			// final Review review = (Review) reviewsList.get(i);
+			// log.debug("Review : rule " + review.ruleName + ", line " +
+			// review.lineNumber);
+			// }
+			// }
+
+		} catch (CoreException e) {
+			PMDPlugin.getDefault().logError("Core Exception when searching reviewed violations", e);
+		} catch (IOException e) {
+			PMDPlugin.getDefault().logError("IO Exception when searching reviewed violations", e);
+		} finally {
+			IOUtil.closeQuietly(reader);
+		}
+
+		return reviews;
+	}
+
+	private MarkerInfo2 getMarkerInfo(RuleViolation violation, String type) throws PropertiesException {
+
+		Rule rule = violation.getRule();
+
+		MarkerInfo2 info = new MarkerInfo2(type, 7);
+
+		info.add(IMarker.MESSAGE, violation.getDescription());
+		info.add(IMarker.LINE_NUMBER, violation.getBeginLine());
+		info.add(PMDRuntimeConstants.KEY_MARKERATT_LINE2, violation.getEndLine());
+		info.add(PMDRuntimeConstants.KEY_MARKERATT_RULENAME, rule.getName());
+		info.add(PMDRuntimeConstants.KEY_MARKERATT_PRIORITY, rule.getPriority().getPriority());
+
+		switch (rule.getPriority().getPriority()) {
+		case 1:
+			info.add(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
+			info.add(IMarker.SEVERITY,
+					projectProperties.violationsAsErrors() ? IMarker.SEVERITY_ERROR : IMarker.SEVERITY_WARNING);
+			break;
+		case 2:
+			if (projectProperties.violationsAsErrors()) {
+				info.add(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
+			} else {
+				info.add(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
+				info.add(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
+			}
+			break;
+
+		case 5:
+			info.add(IMarker.SEVERITY, IMarker.SEVERITY_INFO);
+			break;
+
+		case 3:
+			info.add(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
+			info.add(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
+			break;
+
+		case 4:
+		default:
+			info.add(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
+			info.add(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
+			break;
+		}
+
+		return info;
+	}
+
+	/**
+	 * Private inner type to handle reviews
+	 */
+	private class Review {
+		public String ruleName;
+		public int lineNumber;
+
+		@Override
+		public boolean equals(final Object obj) {
+			boolean result = false;
+			if (obj instanceof Review) {
+				Review reviewObj = (Review) obj;
+				result = ruleName.equals(reviewObj.ruleName) && lineNumber == reviewObj.lineNumber;
+			}
+			return result;
+		}
+
+		@Override
+		public int hashCode() {
+			return ruleName.hashCode() + lineNumber * lineNumber;
+		}
+
+	}
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
@@ -47,6 +47,7 @@ import org.eclipse.core.runtime.IProgressMonitor;
 import org.eclipse.ui.IWorkingSet;
 import org.eclipse.ui.ResourceWorkingSetFilter;
 
+import name.herlin.command.Timer;
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.PMDConfiguration;
 import net.sourceforge.pmd.PMDException;
@@ -65,6 +66,7 @@ import net.sourceforge.pmd.eclipse.runtime.PMDRuntimeConstants;
 import net.sourceforge.pmd.eclipse.runtime.properties.IProjectProperties;
 import net.sourceforge.pmd.eclipse.runtime.properties.PropertiesException;
 import net.sourceforge.pmd.eclipse.util.IOUtil;
+import net.sourceforge.pmd.eclipse.util.PriorityUtil;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.LanguageVersionDiscoverer;
@@ -76,8 +78,6 @@ import net.sourceforge.pmd.util.NumericConstants;
 import net.sourceforge.pmd.util.StringUtil;
 import net.sourceforge.pmd.util.datasource.DataSource;
 import net.sourceforge.pmd.util.datasource.ReaderDataSource;
-
-import name.herlin.command.Timer;
 
 /**
  * Factor some useful features for visitors
@@ -496,6 +496,11 @@ public class BaseVisitor {
             review.ruleName = rule.getName();
             review.lineNumber = violation.getBeginLine();
 
+            /* Only show active violations */
+            if(!PriorityUtil.getActivePriorites().contains(rule.getPriority())) {
+            	continue;
+            }
+            
             if (reviewsList.contains(review)) {
                 LOG.debug("Ignoring violation of rule " + rule.getName() + " at line " + violation.getBeginLine()
                         + " because of a review.");

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/ReviewCodeCmd.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/ReviewCodeCmd.java
@@ -93,623 +93,641 @@ import name.herlin.command.Timer;
  */
 public class ReviewCodeCmd extends AbstractDefaultCommand {
 
-    private static final Logger LOG = Logger.getLogger(ReviewCodeCmd.class);
-
-    private final List<ISchedulingRule> resources = new ArrayList<ISchedulingRule>();
-    private IResourceDelta resourceDelta;
-    private Map<IFile, Set<MarkerInfo2>> markersByFile = new HashMap<IFile, Set<MarkerInfo2>>();
-    private boolean taskMarker;
-    private boolean openPmdPerspective;
-    private int ruleCount;
-    private int fileCount;
-    private long pmdDuration;
-    private String onErrorIssue = null;
-    /**
-     * Whether to run the review command, even if PMD is disabled in the project
-     * settings.
-     */
-    private boolean runAlways = false;
-    /**
-     * Maximum count of changed resources, that are considered to be not a full
-     * build. If more than these resources are changed, PMD will only be
-     * executed, if full build option is enabled.
-     */
-    private static final int MAXIMUM_RESOURCE_COUNT = 5;
-
-    private IProjectProperties propertyCache = null;
-
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * Default constructor
-     */
-    public ReviewCodeCmd() {
-        super("ReviewCode", "Run PMD on a list of workbench resources");
-
-        setOutputProperties(true);
-        setReadOnly(true);
-        setTerminated(false);
-    }
-
-    public Set<IFile> markedFiles() {
-        return markersByFile.keySet();
-    }
-
-    private RuleSet currentRules() {
-        // FIXME
-        return RuleSetUtil.newEmpty(RuleSetUtil.DEFAULT_RULESET_NAME, RuleSetUtil.DEFAULT_RULESET_DESCRIPTION);
-    }
-
-    private Map<Rule, String> misconfiguredRulesIn(RuleSet ruleset) {
-
-        RuleSet ruleSet = currentRules();
-
-        Map<Rule, String> faultsByRule = new HashMap<Rule, String>();
-        for (Rule rule : ruleSet.getRules()) {
-            String fault = rule.dysfunctionReason();
-            if (StringUtil.isNotEmpty(fault)) {
-                faultsByRule.put(rule, fault);
-            }
-        }
-
-        return faultsByRule;
-    }
-
-    private boolean checkForMisconfiguredRules() {
-
-        RuleSet ruleSet = currentRules();
-        if (ruleSet.getRules().isEmpty()) {
-            return true;
-        }
-
-        Map<Rule, String> faultsByRule = misconfiguredRulesIn(ruleSet);
-        if (faultsByRule.isEmpty()) {
-            return true;
-        }
-
-        return MessageDialog.openConfirm(Display.getDefault().getActiveShell(), "Rule configuration problem",
-                "Continue anyways?");
-    }
-
-    /**
-     * @see name.herlin.command.AbstractProcessableCommand#execute()
-     */
-    @Override
-    public void execute() throws CommandException {
-
-        boolean doReview = checkForMisconfiguredRules();
-        if (!doReview) {
-            return;
-        }
-
-        LOG.info("ReviewCode command starting.");
-        try {
-            fileCount = 0;
-            ruleCount = 0;
-            pmdDuration = 0;
-
-            beginTask("PMD checking...", getStepCount());
-
-            // Lancer PMD
-            // PMDPlugin fills resources if it's a full build and
-            // resourcesDelta if it is incremental or auto
-            if (resources.isEmpty()) {
-                processResourceDelta();
-            } else {
-                processResources();
-            }
-
-            // do we really need to do any of the rest of this if
-            // fileCount and ruleCount are both 0?
-
-            // skip the marking processing if the markersByFile set is empty
-            // (avoids grabbing the "run" lock for nothing)
-            if (!markersByFile.isEmpty()) {
-                // Appliquer les marqueurs
-                IWorkspaceRunnable action = new IWorkspaceRunnable() {
-                    public void run(IProgressMonitor monitor) throws CoreException {
-                        applyMarkers();
-                    }
-                };
-
-                // clear the markers here. The call to Resource.deleteMarkers
-                // will
-                // also call the Workspace.prepareOperation so do that
-                // outside the larger "applyMarkers" call to avoid doubly
-                // holding locks
-                // for too long
-                for (IFile file : markersByFile.keySet()) {
-                    if (isCanceled()) {
-                        break;
-                    }
-                    MarkerUtil.deleteAllMarkersIn(file);
-                }
-
-                final IWorkspace workspace = ResourcesPlugin.getWorkspace();
-                workspace.run(action, getSchedulingRule(), IWorkspace.AVOID_UPDATE, getMonitor());
-            }
-
-            // Switch to the PMD perspective if required
-            if (openPmdPerspective) {
-                Display.getDefault().asyncExec(new Runnable() {
-                    public void run() {
-                        switchToPmdPerspective();
-                    }
-                });
-            }
-
-        } catch (CoreException e) {
-            throw new CommandException("Core exception when reviewing code", e);
-        } finally {
-            LOG.info("ReviewCode command has ended.");
-            setTerminated(true);
-            done();
-
-            // Log performance information
-            if (fileCount > 0 && ruleCount > 0) {
-                logInfo("Review code command terminated. " + ruleCount + " rules were executed against " + fileCount
-                        + " files. Actual PMD duration is about " + pmdDuration + "ms, that is about "
-                        + (float) pmdDuration / fileCount + " ms/file, " + (float) pmdDuration / ruleCount
-                        + " ms/rule, " + (float) pmdDuration / ((long) fileCount * (long) ruleCount) + " ms/filerule");
-            } else {
-                logInfo("Review code command terminated. " + ruleCount + " rules were executed against " + fileCount
-                        + " files. PMD was not executed.");
-            }
-        }
-
-        PMDPlugin.getDefault().changedFiles(markedFiles());
-    }
-
-    /**
-     * @return Returns the file markers
-     */
-    public Map<IFile, Set<MarkerInfo2>> getMarkers() {
-        return markersByFile;
-    }
-
-    public int getFileCount() {
-        return fileCount;
-    }
-
-    /**
-     * @param resource
-     *            The resource to set.
-     */
-    public void setResources(Collection<ISchedulingRule> resources) {
-        resources.clear();
-        resources.addAll(resources);
-    }
-
-    /**
-     * Add a resource to the list of resources to be reviewed.
-     *
-     * @param resource
-     *            a workbench resource
-     */
-    public void addResource(IResource resource) {
-        if (resource == null) {
-            throw new IllegalArgumentException("Resource parameter can not be null");
-        }
-
-        resources.add(resource);
-    }
-
-    /**
-     * @param resourceDelta
-     *            The resourceDelta to set.
-     */
-    public void setResourceDelta(IResourceDelta resourceDelta) {
-        this.resourceDelta = resourceDelta;
-    }
-
-    /**
-     * @param taskMarker
-     *            The taskMarker to set.
-     */
-    public void setTaskMarker(boolean taskMarker) {
-        this.taskMarker = taskMarker;
-    }
-
-    public void setRunAlways(boolean runAlways) {
-        this.runAlways = runAlways;
-    }
-
-    /**
-     * @param openPmdPerspective
-     *            Tell whether the PMD perspective should be opened after
-     *            processing.
-     */
-    public void setOpenPmdPerspective(boolean openPmdPerspective) {
-        this.openPmdPerspective = openPmdPerspective;
-    }
-
-    /**
-     * @see name.herlin.command.Command#reset()
-     */
-    @Override
-    public void reset() {
-        resources.clear();
-        markersByFile = new HashMap<IFile, Set<MarkerInfo2>>();
-        setTerminated(false);
-        openPmdPerspective = false;
-        onErrorIssue = null;
-        runAlways = false;
-    }
-
-    /**
-     * @see name.herlin.command.Command#isReadyToExecute()
-     */
-    @Override
-    public boolean isReadyToExecute() {
-        return resources.size() != 0 || resourceDelta != null;
-    }
-
-    /**
-     * @return the scheduling rule needed to apply markers
-     */
-    private ISchedulingRule getSchedulingRule() {
-        final IWorkspace workspace = ResourcesPlugin.getWorkspace();
-        final IResourceRuleFactory ruleFactory = workspace.getRuleFactory();
-        ISchedulingRule rule;
-
-        if (resources.isEmpty()) {
-            rule = ruleFactory.markerRule(resourceDelta.getResource().getProject());
-        } else {
-            ISchedulingRule[] rules = new ISchedulingRule[resources.size()];
-            for (int i = 0; i < rules.length; i++) {
-                rules[i] = ruleFactory.markerRule((IResource) resources.get(i));
-            }
-            rule = new MultiRule(resources.toArray(rules));
-        }
-
-        return rule;
-    }
-
-    /**
-     * Process the list of workbench resources
-     *
-     * @throws CommandException
-     */
-    private void processResources() throws CommandException {
-        final Iterator<ISchedulingRule> i = resources.iterator();
-        while (i.hasNext()) {
-            final IResource resource = (IResource) i.next();
-
-            // if resource is a project, visit only its source folders
-            if (resource instanceof IProject) {
-                processProject((IProject) resource);
-            } else {
-                processResource(resource);
-            }
-        }
-    }
-
-    private IProjectProperties getProjectProperties(IProject project) throws PropertiesException, CommandException {
-        if (propertyCache == null || !propertyCache.getProject().getName().equals(project.getName())) {
-            propertyCache = PMDPlugin.getDefault().loadProjectProperties(project);
-        }
-        return propertyCache;
-    }
-
-    private RuleSet rulesetFrom(IResource resource) throws PropertiesException, CommandException {
-        IProject project = resource.getProject();
-        IProjectProperties properties = getProjectProperties(project);
-
-        return filteredRuleSet(properties); // properties.getProjectRuleSet();
-    }
-
-    /**
-     * Review a single resource
-     */
-    private void processResource(IResource resource) throws CommandException {
-        try {
-
-            final IProject project = resource.getProject();
-            final IProjectProperties properties = getProjectProperties(project);
-            if (!runAlways && !properties.isPmdEnabled()) {
-                return;
-            }
-
-            final RuleSet ruleSet = rulesetFrom(resource); // properties.getProjectRuleSet();
-
-            // final PMDEngine pmdEngine = getPmdEngineForProject(project);
-            int targetCount = 0;
-            if (resource.exists()) {
-                targetCount = countResourceElement(resource);
-            }
-            // Could add a property that lets us set the max number to analyze
-            if (properties.isFullBuildEnabled() || isUserInitiated() || targetCount <= MAXIMUM_RESOURCE_COUNT) {
-                setStepCount(targetCount);
-                LOG.debug("Visiting resource " + resource.getName() + " : " + getStepCount());
-
-                if (resource.exists()) {
-                    final ResourceVisitor visitor = new ResourceVisitor();
-                    visitor.setMonitor(getMonitor());
-                    visitor.setRuleSet(ruleSet);
-                    // visitor.setPmdEngine(pmdEngine);
-                    visitor.setAccumulator(markersByFile);
-                    visitor.setUseTaskMarker(taskMarker);
-                    visitor.setProjectProperties(properties);
-                    resource.accept(visitor);
-
-                    ruleCount = ruleSet.getRules().size();
-                    fileCount += visitor.getProcessedFilesCount();
-                    pmdDuration += visitor.getActualPmdDuration();
-                } else {
-                    LOG.debug("Skipping resource " + resource.getName() + " because it doesn't exist.");
-                }
-            } else {
-                String message = "Skipping resource " + resource.getName() + " because of fullBuildEnabled flag and "
-                        + "targetCount is " + targetCount + ". This is more than " + MAXIMUM_RESOURCE_COUNT + "."
-                        + " If you want to execute PMD, please check \"Full build enabled\" in the project settings";
-                PMDPlugin.getDefault().logInformation(message);
-            }
-
-            worked(1); // TODO - temp fix? BR
-
-        } catch (PropertiesException e) {
-            throw new CommandException(e);
-        } catch (CoreException e) {
-            throw new CommandException(e);
-        }
-    }
-
-    /**
-     * Review an entire project
-     */
-    private void processProject(IProject project) throws CommandException {
-        try {
-            setStepCount(countResourceElement(project));
-            LOG.debug("Visiting  project " + project.getName() + " : " + getStepCount());
-
-            if (project.hasNature(JavaCore.NATURE_ID)) {
-                processJavaProject(project);
-            } else {
-                processResource(project);
-            }
-
-        } catch (CoreException e) {
-            throw new CommandException(e);
-        }
-    }
-
-    private void processJavaProject(IProject project) throws CoreException, CommandException {
-        final IJavaProject javaProject = JavaCore.create(project);
-        final IClasspathEntry[] entries = javaProject.getRawClasspath();
-        final IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
-        for (IClasspathEntry entrie : entries) {
-            if (entrie.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
-
-                // phherlin note: this code is ugly but I don't how to do
-                // otherwise.
-                // The IWorkspaceRoot getContainerLocation(IPath) always
-                // return null.
-                // Catching the IllegalArgumentException on getFolder is the
-                // only way I found
-                // to know if the entry is a folder or a project !
-                IContainer sourceContainer = null;
-                try {
-                    sourceContainer = root.getFolder(entrie.getPath());
-                } catch (IllegalArgumentException e) {
-                    sourceContainer = root.getProject(entrie.getPath().toString());
-                }
-                if (sourceContainer == null) {
-                    LOG.warn("Source container " + entrie.getPath() + " for project " + project.getName()
-                            + " is not valid");
-                } else {
-                    processResource(sourceContainer);
-                }
-            }
-        }
-    }
-
-    private void taskScope(int activeRuleCount, int totalRuleCount) {
-        setTaskName("Checking with " + Integer.toString(activeRuleCount) + " out of " + Integer.toString(totalRuleCount)
-                + " rules");
-    }
-
-    private RuleSet filteredRuleSet(IProjectProperties properties) throws CommandException, PropertiesException {
-
-        final RuleSet ruleSet = properties.getProjectRuleSet();
-        IPreferences preferences = PMDPlugin.getDefault().getPreferencesManager().loadPreferences();
-        Set<String> onlyActiveRuleNames = preferences.getActiveRuleNames();
-
-        int rulesBefore = ruleSet.size();
-        RuleSet filteredRuleSet = RuleSetUtil.newCopyOf(ruleSet);
-        if (preferences.getGlobalRuleManagement()) {
-            // TODO: active rules are not language aware... filter by rule
-            // name...
-            List<Rule> rulesToKeep = new ArrayList<Rule>();
-            for (Rule rule : filteredRuleSet.getRules()) {
-                if (onlyActiveRuleNames.contains(rule.getName())) {
-                    rulesToKeep.add(rule);
-                }
-            }
-            filteredRuleSet = RuleSetUtil.retainOnly(filteredRuleSet, rulesToKeep);
-            int rulesAfter = filteredRuleSet.size();
-
-            if (rulesAfter < rulesBefore) {
-                PMDPlugin.getDefault()
-                        .logWarn("Ruleset has been filtered as Global Rule Management is active. " + rulesAfter + " of "
-                                + rulesBefore + " rules are active and are used. " + (rulesBefore - rulesAfter)
-                                + " rules will be ignored.");
-            }
-        }
-        filteredRuleSet = RuleSetUtil.addExcludePatterns(filteredRuleSet, preferences.activeExclusionPatterns(),
-                properties.getBuildPathExcludePatterns());
-        filteredRuleSet = RuleSetUtil.addIncludePatterns(filteredRuleSet, preferences.activeInclusionPatterns(),
-                properties.getBuildPathIncludePatterns());
-
-        taskScope(filteredRuleSet.getRules().size(), ruleSet.getRules().size());
-        return filteredRuleSet;
-    }
-
-    private RuleSet rulesetFromResourceDelta() throws PropertiesException, CommandException {
-
-        IResource resource = resourceDelta.getResource();
-        final IProject project = resource.getProject();
-        final IProjectProperties properties = getProjectProperties(project);
-
-        return filteredRuleSet(properties); // properties.getProjectRuleSet();
-    }
-
-    /**
-     * Review a resource delta
-     */
-    private void processResourceDelta() throws CommandException {
-        try {
-            IResource resource = resourceDelta.getResource();
-            final IProject project = resource.getProject();
-            final IProjectProperties properties = getProjectProperties(project);
-
-            RuleSet ruleSet = rulesetFromResourceDelta(); // properties.getProjectRuleSet();
-
-            // PMDEngine pmdEngine = getPmdEngineForProject(project);
-            int targetCount = countDeltaElement(resourceDelta);
-            // Could add a property that lets us set the max number to analyze
-            if (properties.isFullBuildEnabled() || isUserInitiated() || targetCount <= MAXIMUM_RESOURCE_COUNT) {
-                setStepCount(targetCount);
-                LOG.debug("Visiting delta of resource " + resource.getName() + " : " + getStepCount());
-
-                DeltaVisitor visitor = new DeltaVisitor();
-                visitor.setMonitor(getMonitor());
-                visitor.setRuleSet(ruleSet);
-                // visitor.setPmdEngine(pmdEngine);
-                visitor.setAccumulator(markersByFile);
-                visitor.setUseTaskMarker(taskMarker);
-                visitor.setProjectProperties(properties);
-                resourceDelta.accept(visitor);
-
-                ruleCount = ruleSet.getRules().size();
-                fileCount += visitor.getProcessedFilesCount();
-                pmdDuration += visitor.getActualPmdDuration();
-            } else {
-                String message = "Skipping resourceDelta " + resource.getName()
-                        + " because of fullBuildEnabled flag and " + "targetCount is " + targetCount
-                        + ". This is more than " + MAXIMUM_RESOURCE_COUNT + "."
-                        + " If you want to execute PMD, please check \"Full build enabled\" in the project settings";
-                PMDPlugin.getDefault().logInformation(message);
-                LOG.debug(message);
-            }
-
-        } catch (PropertiesException e) {
-            throw new CommandException(e);
-        } catch (CoreException e) {
-            throw new CommandException(e);
-        }
-    }
-
-    /**
-     * Apply PMD markers after the review
-     *
-     */
-    private void applyMarkers() {
-        LOG.info("Processing marker directives");
-        int violationCount = 0;
-        final Timer timer = new Timer();
-
-        String currentFile = ""; // for logging
-
-        beginTask("PMD Applying markers", markersByFile.size());
-
-        try {
-            for (IFile file : markersByFile.keySet()) {
-                if (isCanceled()) {
-                    break;
-                }
-                currentFile = file.getName();
-                Set<MarkerInfo2> markerInfoSet = markersByFile.get(file);
-                for (MarkerInfo2 markerInfo : markerInfoSet) {
-                    markerInfo.addAsMarkerTo(file);
-                    violationCount++;
-                }
-
-                worked(1);
-            }
-        } catch (CoreException e) {
-            // TODO: NLS
-            LOG.warn("CoreException when setting marker for file " + currentFile + " : " + e.getMessage());
-        } finally {
-            timer.stop();
-            int count = markersByFile.size();
-            logInfo("" + violationCount + " markers applied on " + count + " files in " + timer.getDuration() + "ms.");
-            LOG.info("End of processing marker directives. " + violationCount + " violations for " + count + " files.");
-        }
-    }
-
-    /**
-     * Count the number of sub-resources of a resource
-     *
-     * @param resource
-     *            a project
-     * @return the element count
-     */
-    private int countResourceElement(IResource resource) {
-
-        if (resource instanceof IFile) {
-            return 1;
-        }
-
-        final CountVisitor visitor = new CountVisitor();
-
-        try {
-            resource.accept(visitor);
-        } catch (CoreException e) {
-            logError("Exception when counting elements of a project", e);
-        }
-
-        return visitor.count;
-    }
-
-    /**
-     * Count the number of sub-resources of a delta
-     *
-     * @param delta
-     *            a resource delta
-     * @return the element count
-     */
-    private int countDeltaElement(IResourceDelta delta) {
-        final CountVisitor visitor = new CountVisitor();
-
-        try {
-            delta.accept(visitor);
-        } catch (CoreException e) {
-            logError("Exception counting elements in a delta selection", e);
-        }
-
-        return visitor.count;
-    }
-
-    /**
-     * opens the PMD perspective
-     *
-     * @author SebastianRaffel ( 07.05.2005 )
-     */
-    private static void switchToPmdPerspective() {
-        final IWorkbench workbench = PlatformUI.getWorkbench();
-        final IPerspectiveRegistry reg = workbench.getPerspectiveRegistry();
-        final IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
-        window.getActivePage().setPerspective(reg.findPerspectiveWithId(PMDRuntimeConstants.ID_PERSPECTIVE));
-    }
-
-    /**
-     * Private inner class to count the number of resources or delta elements.
-     * Only files are counted.
-     */
-    private final class CountVisitor implements IResourceVisitor, IResourceDeltaVisitor {
-        public int count = 0;
-
-        public boolean visit(IResource resource) {
-            if (resource instanceof IFile) {
-                count++;
-            }
-            return true;
-        }
-
-        public boolean visit(IResourceDelta delta) {
-            IResource resource = delta.getResource();
-            return visit(resource);
-        }
-    }
+	private static final Logger LOG = Logger.getLogger(ReviewCodeCmd.class);
+
+	private final List<ISchedulingRule> resources = new ArrayList<ISchedulingRule>();
+	private IResourceDelta resourceDelta;
+	private Map<IFile, Set<MarkerInfo2>> markersByFile = new HashMap<IFile, Set<MarkerInfo2>>();
+	private boolean taskMarker;
+	private boolean openPmdPerspective;
+	private int ruleCount;
+	private int fileCount;
+	private long pmdDuration;
+	private String onErrorIssue = null;
+	/**
+	 * Whether to run the review command, even if PMD is disabled in the project
+	 * settings.
+	 */
+	private boolean runAlways = false;
+	/**
+	 * Maximum count of changed resources, that are considered to be not a full
+	 * build. If more than these resources are changed, PMD will only be executed,
+	 * if full build option is enabled.
+	 */
+	private static final int MAXIMUM_RESOURCE_COUNT = 5;
+
+	private IProjectProperties propertyCache = null;
+
+	private static final long serialVersionUID = 1L;
+
+	/**
+	 * Default constructor
+	 */
+	public ReviewCodeCmd() {
+		super("ReviewCode", "Run PMD on a list of workbench resources");
+
+		setOutputProperties(true);
+		setReadOnly(true);
+		setTerminated(false);
+	}
+
+	public Set<IFile> markedFiles() {
+		return markersByFile.keySet();
+	}
+
+	/**
+	 * Easy way to refresh a set of files.
+	 * 
+	 * @param files
+	 * @throws CommandException
+	 */
+	public static void runCodeReviewOnFiles(Set<IFile> files) throws CommandException {
+		ReviewCodeCmd cmd = new ReviewCodeCmd();
+		cmd.setStepCount(files.size());
+		cmd.setTaskMarker(true);
+		cmd.setOpenPmdPerspective(PMDPlugin.getDefault().loadPreferences().isPmdPerspectiveEnabled());
+		cmd.setUserInitiated(true);
+		cmd.setRunAlways(true);
+		for (IResource file : files) {
+			cmd.addResource(file);
+		}
+		cmd.performExecute();
+	}
+
+	private RuleSet currentRules() {
+		// FIXME
+		return RuleSetUtil.newEmpty(RuleSetUtil.DEFAULT_RULESET_NAME, RuleSetUtil.DEFAULT_RULESET_DESCRIPTION);
+	}
+
+	private Map<Rule, String> misconfiguredRulesIn(RuleSet ruleset) {
+
+		RuleSet ruleSet = currentRules();
+
+		Map<Rule, String> faultsByRule = new HashMap<Rule, String>();
+		for (Rule rule : ruleSet.getRules()) {
+			String fault = rule.dysfunctionReason();
+			if (StringUtil.isNotEmpty(fault)) {
+				faultsByRule.put(rule, fault);
+			}
+		}
+
+		return faultsByRule;
+	}
+
+	private boolean checkForMisconfiguredRules() {
+
+		RuleSet ruleSet = currentRules();
+		if (ruleSet.getRules().isEmpty()) {
+			return true;
+		}
+
+		Map<Rule, String> faultsByRule = misconfiguredRulesIn(ruleSet);
+		if (faultsByRule.isEmpty()) {
+			return true;
+		}
+
+		return MessageDialog.openConfirm(Display.getDefault().getActiveShell(), "Rule configuration problem",
+				"Continue anyways?");
+	}
+
+	/**
+	 * @see name.herlin.command.AbstractProcessableCommand#execute()
+	 */
+	@Override
+	public void execute() throws CommandException {
+
+		boolean doReview = checkForMisconfiguredRules();
+		if (!doReview) {
+			return;
+		}
+
+		LOG.info("ReviewCode command starting.");
+		try {
+			fileCount = 0;
+			ruleCount = 0;
+			pmdDuration = 0;
+
+			beginTask("PMD checking...", getStepCount());
+
+			// Lancer PMD
+			// PMDPlugin fills resources if it's a full build and
+			// resourcesDelta if it is incremental or auto
+			if (resources.isEmpty()) {
+				processResourceDelta();
+			} else {
+				processResources();
+			}
+
+			// do we really need to do any of the rest of this if
+			// fileCount and ruleCount are both 0?
+
+			// skip the marking processing if the markersByFile set is empty
+			// (avoids grabbing the "run" lock for nothing)
+			if (!markersByFile.isEmpty()) {
+				// Appliquer les marqueurs
+				IWorkspaceRunnable action = new IWorkspaceRunnable() {
+					public void run(IProgressMonitor monitor) throws CoreException {
+						applyMarkers();
+					}
+				};
+
+				// clear the markers here. The call to Resource.deleteMarkers
+				// will
+				// also call the Workspace.prepareOperation so do that
+				// outside the larger "applyMarkers" call to avoid doubly
+				// holding locks
+				// for too long
+				for (IFile file : markersByFile.keySet()) {
+					if (isCanceled()) {
+						break;
+					}
+					MarkerUtil.deleteAllMarkersIn(file);
+				}
+
+				final IWorkspace workspace = ResourcesPlugin.getWorkspace();
+				workspace.run(action, getSchedulingRule(), IWorkspace.AVOID_UPDATE, getMonitor());
+			}
+
+			// Switch to the PMD perspective if required
+			if (openPmdPerspective) {
+				Display.getDefault().asyncExec(new Runnable() {
+					public void run() {
+						switchToPmdPerspective();
+					}
+				});
+			}
+
+		} catch (CoreException e) {
+			throw new CommandException("Core exception when reviewing code", e);
+		} finally {
+			LOG.info("ReviewCode command has ended.");
+			setTerminated(true);
+			done();
+
+			// Log performance information
+			if (fileCount > 0 && ruleCount > 0) {
+				logInfo("Review code command terminated. " + ruleCount + " rules were executed against " + fileCount
+						+ " files. Actual PMD duration is about " + pmdDuration + "ms, that is about "
+						+ (float) pmdDuration / fileCount + " ms/file, " + (float) pmdDuration / ruleCount
+						+ " ms/rule, " + (float) pmdDuration / ((long) fileCount * (long) ruleCount) + " ms/filerule");
+			} else {
+				logInfo("Review code command terminated. " + ruleCount + " rules were executed against " + fileCount
+						+ " files. PMD was not executed.");
+			}
+		}
+
+		PMDPlugin.getDefault().changedFiles(markedFiles());
+	}
+
+	/**
+	 * @return Returns the file markers
+	 */
+	public Map<IFile, Set<MarkerInfo2>> getMarkers() {
+		return markersByFile;
+	}
+
+	public int getFileCount() {
+		return fileCount;
+	}
+
+	/**
+	 * @param resource
+	 *            The resource to set.
+	 */
+	public void setResources(Collection<ISchedulingRule> resources) {
+		resources.clear();
+		resources.addAll(resources);
+	}
+
+	/**
+	 * Add a resource to the list of resources to be reviewed.
+	 *
+	 * @param resource
+	 *            a workbench resource
+	 */
+	public void addResource(IResource resource) {
+		if (resource == null) {
+			throw new IllegalArgumentException("Resource parameter can not be null");
+		}
+
+		resources.add(resource);
+	}
+
+	/**
+	 * @param resourceDelta
+	 *            The resourceDelta to set.
+	 */
+	public void setResourceDelta(IResourceDelta resourceDelta) {
+		this.resourceDelta = resourceDelta;
+	}
+
+	/**
+	 * @param taskMarker
+	 *            The taskMarker to set.
+	 */
+	public void setTaskMarker(boolean taskMarker) {
+		this.taskMarker = taskMarker;
+	}
+
+	public void setRunAlways(boolean runAlways) {
+		this.runAlways = runAlways;
+	}
+
+	/**
+	 * @param openPmdPerspective
+	 *            Tell whether the PMD perspective should be opened after
+	 *            processing.
+	 */
+	public void setOpenPmdPerspective(boolean openPmdPerspective) {
+		this.openPmdPerspective = openPmdPerspective;
+	}
+
+	/**
+	 * @see name.herlin.command.Command#reset()
+	 */
+	@Override
+	public void reset() {
+		resources.clear();
+		markersByFile = new HashMap<IFile, Set<MarkerInfo2>>();
+		setTerminated(false);
+		openPmdPerspective = false;
+		onErrorIssue = null;
+		runAlways = false;
+	}
+
+	/**
+	 * @see name.herlin.command.Command#isReadyToExecute()
+	 */
+	@Override
+	public boolean isReadyToExecute() {
+		return resources.size() != 0 || resourceDelta != null;
+	}
+
+	/**
+	 * @return the scheduling rule needed to apply markers
+	 */
+	private ISchedulingRule getSchedulingRule() {
+		final IWorkspace workspace = ResourcesPlugin.getWorkspace();
+		final IResourceRuleFactory ruleFactory = workspace.getRuleFactory();
+		ISchedulingRule rule;
+
+		if (resources.isEmpty()) {
+			rule = ruleFactory.markerRule(resourceDelta.getResource().getProject());
+		} else {
+			ISchedulingRule[] rules = new ISchedulingRule[resources.size()];
+			for (int i = 0; i < rules.length; i++) {
+				rules[i] = ruleFactory.markerRule((IResource) resources.get(i));
+			}
+			rule = new MultiRule(resources.toArray(rules));
+		}
+
+		return rule;
+	}
+
+	/**
+	 * Process the list of workbench resources
+	 *
+	 * @throws CommandException
+	 */
+	private void processResources() throws CommandException {
+		final Iterator<ISchedulingRule> i = resources.iterator();
+		while (i.hasNext()) {
+			final IResource resource = (IResource) i.next();
+
+			// if resource is a project, visit only its source folders
+			if (resource instanceof IProject) {
+				processProject((IProject) resource);
+			} else {
+				processResource(resource);
+			}
+		}
+	}
+
+	private IProjectProperties getProjectProperties(IProject project) throws PropertiesException, CommandException {
+		if (propertyCache == null || !propertyCache.getProject().getName().equals(project.getName())) {
+			propertyCache = PMDPlugin.getDefault().loadProjectProperties(project);
+		}
+		return propertyCache;
+	}
+
+	private RuleSet rulesetFrom(IResource resource) throws PropertiesException, CommandException {
+		IProject project = resource.getProject();
+		IProjectProperties properties = getProjectProperties(project);
+
+		return filteredRuleSet(properties); // properties.getProjectRuleSet();
+	}
+
+	/**
+	 * Review a single resource
+	 */
+	private void processResource(IResource resource) throws CommandException {
+		try {
+
+			final IProject project = resource.getProject();
+			final IProjectProperties properties = getProjectProperties(project);
+			if (!runAlways && !properties.isPmdEnabled()) {
+				return;
+			}
+
+			final RuleSet ruleSet = rulesetFrom(resource); // properties.getProjectRuleSet();
+
+			// final PMDEngine pmdEngine = getPmdEngineForProject(project);
+			int targetCount = 0;
+			if (resource.exists()) {
+				targetCount = countResourceElement(resource);
+			}
+			// Could add a property that lets us set the max number to analyze
+			if (properties.isFullBuildEnabled() || isUserInitiated() || targetCount <= MAXIMUM_RESOURCE_COUNT) {
+				setStepCount(targetCount);
+				LOG.debug("Visiting resource " + resource.getName() + " : " + getStepCount());
+				if (resource.exists()) {
+					final ResourceVisitor visitor = new ResourceVisitor();
+					visitor.setMonitor(getMonitor());
+					visitor.setRuleSet(ruleSet);
+					// visitor.setPmdEngine(pmdEngine);
+					visitor.setAccumulator(markersByFile);
+					visitor.setUseTaskMarker(taskMarker);
+					visitor.setProjectProperties(properties);
+					resource.accept(visitor);
+
+					ruleCount = ruleSet.getRules().size();
+					fileCount += visitor.getProcessedFilesCount();
+					pmdDuration += visitor.getActualPmdDuration();
+				} else {
+					LOG.debug("Skipping resource " + resource.getName() + " because it doesn't exist.");
+				}
+			} else {
+				String message = "Skipping resource " + resource.getName() + " because of fullBuildEnabled flag and "
+						+ "targetCount is " + targetCount + ". This is more than " + MAXIMUM_RESOURCE_COUNT + "."
+						+ " If you want to execute PMD, please check \"Full build enabled\" in the project settings";
+				PMDPlugin.getDefault().logInformation(message);
+			}
+
+			worked(1); // TODO - temp fix? BR
+
+		} catch (PropertiesException e) {
+			throw new CommandException(e);
+		} catch (CoreException e) {
+			throw new CommandException(e);
+		}
+	}
+
+	/**
+	 * Review an entire project
+	 */
+	private void processProject(IProject project) throws CommandException {
+		try {
+			setStepCount(countResourceElement(project));
+			LOG.debug("Visiting  project " + project.getName() + " : " + getStepCount());
+
+			if (project.hasNature(JavaCore.NATURE_ID)) {
+				processJavaProject(project);
+			} else {
+				processResource(project);
+			}
+
+		} catch (CoreException e) {
+			throw new CommandException(e);
+		}
+	}
+
+	private void processJavaProject(IProject project) throws CoreException, CommandException {
+		final IJavaProject javaProject = JavaCore.create(project);
+		final IClasspathEntry[] entries = javaProject.getRawClasspath();
+		final IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
+		for (IClasspathEntry entrie : entries) {
+			if (entrie.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
+
+				// phherlin note: this code is ugly but I don't how to do
+				// otherwise.
+				// The IWorkspaceRoot getContainerLocation(IPath) always
+				// return null.
+				// Catching the IllegalArgumentException on getFolder is the
+				// only way I found
+				// to know if the entry is a folder or a project !
+				IContainer sourceContainer = null;
+				try {
+					sourceContainer = root.getFolder(entrie.getPath());
+				} catch (IllegalArgumentException e) {
+					sourceContainer = root.getProject(entrie.getPath().toString());
+				}
+				if (sourceContainer == null) {
+					LOG.warn("Source container " + entrie.getPath() + " for project " + project.getName()
+							+ " is not valid");
+				} else {
+					processResource(sourceContainer);
+				}
+			}
+		}
+	}
+
+	private void taskScope(int activeRuleCount, int totalRuleCount) {
+		setTaskName("Checking with " + Integer.toString(activeRuleCount) + " out of " + Integer.toString(totalRuleCount)
+				+ " rules");
+	}
+
+	private RuleSet filteredRuleSet(IProjectProperties properties) throws CommandException, PropertiesException {
+
+		final RuleSet ruleSet = properties.getProjectRuleSet();
+		IPreferences preferences = PMDPlugin.getDefault().getPreferencesManager().loadPreferences();
+		Set<String> onlyActiveRuleNames = preferences.getActiveRuleNames();
+
+		int rulesBefore = ruleSet.size();
+		RuleSet filteredRuleSet = RuleSetUtil.newCopyOf(ruleSet);
+		if (preferences.getGlobalRuleManagement()) {
+			// TODO: active rules are not language aware... filter by rule
+			// name...
+			List<Rule> rulesToKeep = new ArrayList<Rule>();
+			for (Rule rule : filteredRuleSet.getRules()) {
+				if (onlyActiveRuleNames.contains(rule.getName())) {
+					rulesToKeep.add(rule);
+				}
+			}
+			filteredRuleSet = RuleSetUtil.retainOnly(filteredRuleSet, rulesToKeep);
+			int rulesAfter = filteredRuleSet.size();
+
+			if (rulesAfter < rulesBefore) {
+				PMDPlugin.getDefault()
+						.logWarn("Ruleset has been filtered as Global Rule Management is active. " + rulesAfter + " of "
+								+ rulesBefore + " rules are active and are used. " + (rulesBefore - rulesAfter)
+								+ " rules will be ignored.");
+			}
+		}
+		filteredRuleSet = RuleSetUtil.addExcludePatterns(filteredRuleSet, preferences.activeExclusionPatterns(),
+				properties.getBuildPathExcludePatterns());
+		filteredRuleSet = RuleSetUtil.addIncludePatterns(filteredRuleSet, preferences.activeInclusionPatterns(),
+				properties.getBuildPathIncludePatterns());
+
+		taskScope(filteredRuleSet.getRules().size(), ruleSet.getRules().size());
+		return filteredRuleSet;
+	}
+
+	private RuleSet rulesetFromResourceDelta() throws PropertiesException, CommandException {
+
+		IResource resource = resourceDelta.getResource();
+		final IProject project = resource.getProject();
+		final IProjectProperties properties = getProjectProperties(project);
+
+		return filteredRuleSet(properties); // properties.getProjectRuleSet();
+	}
+
+	/**
+	 * Review a resource delta
+	 */
+	private void processResourceDelta() throws CommandException {
+		try {
+			IResource resource = resourceDelta.getResource();
+			final IProject project = resource.getProject();
+			final IProjectProperties properties = getProjectProperties(project);
+
+			RuleSet ruleSet = rulesetFromResourceDelta(); // properties.getProjectRuleSet();
+
+			// PMDEngine pmdEngine = getPmdEngineForProject(project);
+			int targetCount = countDeltaElement(resourceDelta);
+			// Could add a property that lets us set the max number to analyze
+			if (properties.isFullBuildEnabled() || isUserInitiated() || targetCount <= MAXIMUM_RESOURCE_COUNT) {
+				setStepCount(targetCount);
+				LOG.debug("Visiting delta of resource " + resource.getName() + " : " + getStepCount());
+
+				DeltaVisitor visitor = new DeltaVisitor();
+				visitor.setMonitor(getMonitor());
+				visitor.setRuleSet(ruleSet);
+				// visitor.setPmdEngine(pmdEngine);
+				visitor.setAccumulator(markersByFile);
+				visitor.setUseTaskMarker(taskMarker);
+				visitor.setProjectProperties(properties);
+				resourceDelta.accept(visitor);
+
+				ruleCount = ruleSet.getRules().size();
+				fileCount += visitor.getProcessedFilesCount();
+				pmdDuration += visitor.getActualPmdDuration();
+			} else {
+				String message = "Skipping resourceDelta " + resource.getName()
+						+ " because of fullBuildEnabled flag and " + "targetCount is " + targetCount
+						+ ". This is more than " + MAXIMUM_RESOURCE_COUNT + "."
+						+ " If you want to execute PMD, please check \"Full build enabled\" in the project settings";
+				PMDPlugin.getDefault().logInformation(message);
+				LOG.debug(message);
+			}
+
+		} catch (PropertiesException e) {
+			throw new CommandException(e);
+		} catch (CoreException e) {
+			throw new CommandException(e);
+		}
+	}
+
+	/**
+	 * Apply PMD markers after the review
+	 *
+	 */
+	private void applyMarkers() {
+		LOG.info("Processing marker directives");
+		int violationCount = 0;
+		final Timer timer = new Timer();
+
+		String currentFile = ""; // for logging
+
+		beginTask("PMD Applying markers", markersByFile.size());
+
+		try {
+			for (IFile file : markersByFile.keySet()) {
+				if (isCanceled()) {
+					break;
+				}
+				currentFile = file.getName();
+				Set<MarkerInfo2> markerInfoSet = markersByFile.get(file);
+				for (MarkerInfo2 markerInfo : markerInfoSet) {
+					markerInfo.addAsMarkerTo(file);
+					violationCount++;
+				}
+
+				worked(1);
+			}
+		} catch (CoreException e) {
+			// TODO: NLS
+			LOG.warn("CoreException when setting marker for file " + currentFile + " : " + e.getMessage());
+		} finally {
+			timer.stop();
+			int count = markersByFile.size();
+			logInfo("" + violationCount + " markers applied on " + count + " files in " + timer.getDuration() + "ms.");
+			LOG.info("End of processing marker directives. " + violationCount + " violations for " + count + " files.");
+		}
+	}
+
+	/**
+	 * Count the number of sub-resources of a resource
+	 *
+	 * @param resource
+	 *            a project
+	 * @return the element count
+	 */
+	private int countResourceElement(IResource resource) {
+
+		if (resource instanceof IFile) {
+			return 1;
+		}
+
+		final CountVisitor visitor = new CountVisitor();
+
+		try {
+			resource.accept(visitor);
+		} catch (CoreException e) {
+			logError("Exception when counting elements of a project", e);
+		}
+
+		return visitor.count;
+	}
+
+	/**
+	 * Count the number of sub-resources of a delta
+	 *
+	 * @param delta
+	 *            a resource delta
+	 * @return the element count
+	 */
+	private int countDeltaElement(IResourceDelta delta) {
+		final CountVisitor visitor = new CountVisitor();
+
+		try {
+			delta.accept(visitor);
+		} catch (CoreException e) {
+			logError("Exception counting elements in a delta selection", e);
+		}
+
+		return visitor.count;
+	}
+
+	/**
+	 * opens the PMD perspective
+	 *
+	 * @author SebastianRaffel ( 07.05.2005 )
+	 */
+	private static void switchToPmdPerspective() {
+		final IWorkbench workbench = PlatformUI.getWorkbench();
+		final IPerspectiveRegistry reg = workbench.getPerspectiveRegistry();
+		final IWorkbenchWindow window = workbench.getActiveWorkbenchWindow();
+		window.getActivePage().setPerspective(reg.findPerspectiveWithId(PMDRuntimeConstants.ID_PERSPECTIVE));
+	}
+
+	/**
+	 * Private inner class to count the number of resources or delta elements. Only
+	 * files are counted.
+	 */
+	private final class CountVisitor implements IResourceVisitor, IResourceDeltaVisitor {
+		public int count = 0;
+
+		public boolean visit(IResource resource) {
+			if (resource instanceof IFile) {
+				count++;
+			}
+			return true;
+		}
+
+		public boolean visit(IResourceDelta delta) {
+			IResource resource = delta.getResource();
+			return visit(resource);
+		}
+	}
 
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/RuleTableViewerSorter.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/RuleTableViewerSorter.java
@@ -148,9 +148,9 @@ public class RuleTableViewerSorter extends ViewerSorter {
     /**
      * @return Returns the comparator.
      */
-//    public Comparator<Rule> getComparator() {
-//        return comparator;
-//    }
+    public Comparator<Rule> getComparator() {
+        return comparator;
+    }
 
     /**
      * Set a comparator. If the same comparator is already set, then change the

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/RuleTableViewerSorter.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/RuleTableViewerSorter.java
@@ -148,9 +148,9 @@ public class RuleTableViewerSorter extends ViewerSorter {
     /**
      * @return Returns the comparator.
      */
-    public Comparator<Rule> getComparator() {
-        return comparator;
-    }
+//    public Comparator<Rule> getComparator() {
+//        return comparator;
+//    }
 
     /**
      * Set a comparator. If the same comparator is already set, then change the

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ViolationOverview.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ViolationOverview.java
@@ -129,7 +129,7 @@ public class ViolationOverview extends ViewPart implements ISelectionProvider, I
         root = (RootRecord) getInitialInput();
         contentProvider = new ViolationOverviewContentProvider(this);
         labelProvider = new ViolationOverviewLabelProvider(this);
-        priorityFilter = new PriorityFilter();
+        priorityFilter = PriorityUtil.getPriorityFilter();
         projectFilter = new ProjectFilter();
         doubleClickListener = new ViolationOverviewDoubleClickListener(this);
         menuManager = new ViolationOverviewMenuManager(this);
@@ -498,7 +498,6 @@ public class ViolationOverview extends ViewPart implements ISelectionProvider, I
         if (!priorityList.isEmpty()) {
             priorityFilter.setPriorityFilterList(priorityList);
         }
-        PriorityUtil.setPriorityFilter(priorityFilter);
         
         List<String> projectNames = memento.getStringList(PROJECT_LIST);
         if (!projectNames.isEmpty()) {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ViolationOverview.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ViolationOverview.java
@@ -64,6 +64,7 @@ import org.eclipse.ui.IViewSite;
 import org.eclipse.ui.PartInitException;
 import org.eclipse.ui.part.ViewPart;
 
+import name.herlin.command.CommandException;
 import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
 import net.sourceforge.pmd.eclipse.runtime.builder.MarkerUtil;
 import net.sourceforge.pmd.eclipse.runtime.cmd.DeleteMarkersCommand;
@@ -75,9 +76,8 @@ import net.sourceforge.pmd.eclipse.ui.model.MarkerRecord;
 import net.sourceforge.pmd.eclipse.ui.model.PackageRecord;
 import net.sourceforge.pmd.eclipse.ui.model.RootRecord;
 import net.sourceforge.pmd.eclipse.ui.nls.StringKeys;
+import net.sourceforge.pmd.eclipse.util.PriorityUtil;
 import net.sourceforge.pmd.util.NumericConstants;
-
-import name.herlin.command.CommandException;
 
 /**
  * A View for PMD-Violations, provides an Overview as well as statistical
@@ -498,7 +498,8 @@ public class ViolationOverview extends ViewPart implements ISelectionProvider, I
         if (!priorityList.isEmpty()) {
             priorityFilter.setPriorityFilterList(priorityList);
         }
-
+        PriorityUtil.setPriorityFilter(priorityFilter);
+        
         List<String> projectNames = memento.getStringList(PROJECT_LIST);
         if (!projectNames.isEmpty()) {
             List<AbstractPMDRecord> projectList = new ArrayList<AbstractPMDRecord>();

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ViolationOverviewMenuManager.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/ViolationOverviewMenuManager.java
@@ -59,6 +59,7 @@ import net.sourceforge.pmd.eclipse.ui.views.actions.CollapseAllAction;
 import net.sourceforge.pmd.eclipse.ui.views.actions.PriorityFilterAction;
 import net.sourceforge.pmd.eclipse.ui.views.actions.ProjectFilterAction;
 import net.sourceforge.pmd.eclipse.ui.views.actions.ViolationPresentationTypeAction;
+import net.sourceforge.pmd.eclipse.util.PriorityUtil;
 
 /**
  *
@@ -85,8 +86,7 @@ public class ViolationOverviewMenuManager {
         // create the Actions for the PriorityFilter
         for (int i = 0; i < priorities.length; i++) {
             priorityActions[i] = new PriorityFilterAction(priorities[i], overview); // NOPMD by Herlin on 09/10/06 15:02
-            boolean check = overview.getPriorityFilterList().contains(priorities[i].getPriority());
-            priorityActions[i].setChecked(check);
+            priorityActions[i].setChecked(PriorityUtil.isPriorityActive(priorities[i]));
         }
     }
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/actions/PriorityFilterAction.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/actions/PriorityFilterAction.java
@@ -1,15 +1,11 @@
 
 package net.sourceforge.pmd.eclipse.ui.views.actions;
 
-import org.eclipse.core.resources.IFile;
+import org.apache.log4j.Logger;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IEditorReference;
-import org.eclipse.ui.IWorkbenchPart;
-import org.eclipse.ui.PlatformUI;
 
 import name.herlin.command.CommandException;
 import net.sourceforge.pmd.RulePriority;
@@ -34,6 +30,7 @@ public class PriorityFilterAction extends Action {
     private ViolationOverview overviewView;
     private PriorityFilter priorityFilter;
     private final RulePriority priority;
+    private static final Logger LOG = Logger.getLogger(PriorityFilterAction.class);
 
     private PriorityFilterAction(ViewerFilter[] filters, RulePriority thePriority) {
         priority = thePriority;
@@ -165,7 +162,7 @@ public class PriorityFilterAction extends Action {
         try {
 			ReviewCodeCmd.runCodeReviewOnFiles(PMDPlugin.getDefault().getOpenFiles());
 		} catch (CommandException e) {
-			Log.error(e);
+			LOG.error(e);
 		}
     }
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/actions/PriorityFilterAction.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/actions/PriorityFilterAction.java
@@ -1,17 +1,26 @@
 
 package net.sourceforge.pmd.eclipse.ui.views.actions;
 
-import net.sourceforge.pmd.RulePriority;
-import net.sourceforge.pmd.eclipse.plugin.UISettings;
-import net.sourceforge.pmd.eclipse.ui.priority.PriorityDescriptor;
-import net.sourceforge.pmd.eclipse.ui.views.PriorityFilter;
-import net.sourceforge.pmd.eclipse.ui.views.ViolationOutline;
-import net.sourceforge.pmd.eclipse.ui.views.ViolationOverview;
-
+import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.action.Action;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.viewers.ViewerFilter;
 import org.eclipse.swt.widgets.Display;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IEditorReference;
+import org.eclipse.ui.IWorkbenchPart;
+import org.eclipse.ui.PlatformUI;
+
+import name.herlin.command.CommandException;
+import net.sourceforge.pmd.RulePriority;
+import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
+import net.sourceforge.pmd.eclipse.plugin.UISettings;
+import net.sourceforge.pmd.eclipse.runtime.cmd.ReviewCodeCmd;
+import net.sourceforge.pmd.eclipse.ui.priority.PriorityDescriptor;
+import net.sourceforge.pmd.eclipse.ui.views.PriorityFilter;
+import net.sourceforge.pmd.eclipse.ui.views.ViolationOutline;
+import net.sourceforge.pmd.eclipse.ui.views.ViolationOverview;
+import scala.tools.jline_embedded.internal.Log;
 
 /**
  * Filters elements by the Marker priorities
@@ -151,6 +160,13 @@ public class PriorityFilterAction extends Action {
             outlineView.refresh();
         else if (overviewView != null)
             overviewView.refresh();
+        
+        /* Get all the opened files and tell them to run a "review code" on the file */
+        try {
+			ReviewCodeCmd.runCodeReviewOnFiles(PMDPlugin.getDefault().getOpenFiles());
+		} catch (CommandException e) {
+			Log.error(e);
+		}
     }
 
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/util/PriorityUtil.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/util/PriorityUtil.java
@@ -19,10 +19,7 @@ import net.sourceforge.pmd.eclipse.ui.views.PriorityFilter;
 public class PriorityUtil {
 
 	private static PriorityFilter priorityFilter = new PriorityFilter();
-	static {
-		UISettings.currentPriorities(true);
-	}
-
+	
 	private PriorityUtil() {
 	}
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/util/PriorityUtil.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/util/PriorityUtil.java
@@ -1,0 +1,62 @@
+package net.sourceforge.pmd.eclipse.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sourceforge.pmd.RulePriority;
+import net.sourceforge.pmd.eclipse.plugin.UISettings;
+import net.sourceforge.pmd.eclipse.ui.views.PriorityFilter;
+
+/**
+ * Priority Util is a manager of the available priorities in the app. This Util
+ * will update if the Violations Overview Priority Filter updates which will
+ * cause the File markers, Tree Markers, and Violation Outline markers to
+ * update.
+ * 
+ * @author Phillip Krall
+ *
+ */
+public class PriorityUtil {
+
+	private static PriorityFilter priorityFilter = new PriorityFilter();
+	static {
+		UISettings.currentPriorities(true);
+	}
+
+	private PriorityUtil() {
+	}
+
+	/**
+	 * Check if a priority is turned on or not
+	 * 
+	 * @param priority
+	 * @return
+	 */
+	public static boolean isPriorityActive(RulePriority priority) {
+		return getActivePriorites().contains(priority);
+	}
+
+	/**
+	 * Get all the priorities that are turned on right now.
+	 * 
+	 * @return
+	 */
+	public static List<RulePriority> getActivePriorites() {
+		List<RulePriority> active = new ArrayList<RulePriority>();
+		for (RulePriority priority : UISettings.currentPriorities(true)) {
+			if (priorityFilter.getPriorityFilterList().contains(priority.getPriority())) {
+				active.add(priority);
+			}
+		}
+		return active;
+	}
+
+	public static PriorityFilter getPriorityFilter() {
+		return priorityFilter;
+	}
+
+	public static void setPriorityFilter(PriorityFilter priorityFilter) {
+		PriorityUtil.priorityFilter = priorityFilter;
+	}
+
+}


### PR DESCRIPTION
This turns the filter on the violations overview into a global filter. When the user changes that filter it will then filter the markers on the file, tree view, and violations outline. It will also automatically run a check code on the open files.

New parts of the code:
- There is a new PriorityUtil which allows use to access the the currently active priorities
- Added a static runCodeReviewOnFiles on the ReviewCodeCmd, so I didn't have to copy and paste the command to run the review code
- Added getOpenFiles to the plugin to pulls all the files the user has open in the editor, so I can refresh them.


Sorry about the couple of files that got auto formatted. If it is an issue, I can revert them and reapply the changes. 