### PR TITLE
Update to PMD 6.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <tycho.version>1.1.0</tycho.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <pmd.version>6.6.0</pmd.version>
+    <pmd.version>6.7.0</pmd.version>
     <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
   </properties>
 


### PR DESCRIPTION
In PMD 6.7.0 new rule(s) were introduced. To get the Eclipse plugin running in an existing project I needed to update the dependency to PMD 6.7.0 to resolve unknown rule errors. Since I built the new version and use it in my Eclipse, I thought i'd share the minimal change to make it available to all SNAPSHOT users of the plugin.