### PR TITLE
Support Eclipse SimRel 2018-09

### DIFF
--- a/net.sourceforge.pmd.eclipse.plugin.test/META-INF/MANIFEST.MF
+++ b/net.sourceforge.pmd.eclipse.plugin.test/META-INF/MANIFEST.MF
@@ -12,4 +12,6 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.jdt,
  org.eclipse.jdt.core,
  org.eclipse.jdt.launching,
- org.junit
+ org.junit,
+ org.apache.log4j,
+ org.apache.commons.io

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesManagerImplTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesManagerImplTest.java
@@ -13,6 +13,7 @@ public class ProjectPropertiesManagerImplTest {
     public void testToString() throws Exception {
         ProjectPropertiesTO projectProperties = createProjectProperties();
         String expected = IOUtils.toString(this.getClass().getResourceAsStream("projectproperties.xml"));
+        expected = expected.replaceAll("\r\n", "\n");
 
         String s = manager.convertProjectPropertiesToString(projectProperties);
         Assert.assertEquals(expected, s);

--- a/net.sourceforge.pmd.eclipse.plugin/META-INF/MANIFEST.MF
+++ b/net.sourceforge.pmd.eclipse.plugin/META-INF/MANIFEST.MF
@@ -153,6 +153,4 @@ Export-Package: name.herlin.command,
  net.sourceforge.pmd.properties.builders,
  net.sourceforge.pmd.renderers,
  net.sourceforge.pmd.util;uses:="net.sourceforge.pmd.lang.java.ast",
- net.sourceforge.pmd.util.datasource,
- org.apache.commons.io;x-internal:=true,
- org.apache.log4j;uses:="org.apache.log4j.helpers,org.apache.log4j.or,org.apache.log4j.spi"
+ net.sourceforge.pmd.util.datasource


### PR DESCRIPTION
* Remove org.apache.commons.io and org.apache.log4j from exports
* Added above to dependencies for test project
* Modification to test due to EOL conversions done by Git on Windows