### PR TITLE
PMD Markers are now problem markers

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -11,10 +11,17 @@ Eclipse Update Site:
 
 ### New and noteworthy
 
+*   PMD markers are now problem markers again. This means, that rule violations appear in the Problem View.
+    The project property "Handle high priority violations as Eclipse errors" now works again.
+*   The PMD markers are now also visible on the overview ruler. They can be customized or disabled via
+    workspace preferences, General, Editors, Text Editors, Annotations.
+
 ### Fixed Issues
 
+*   [#54](https://github.com/pmd/pmd-eclipse-plugin/issues/54): "violationsAsErrors" is completely ineffective
 *   [#70](https://github.com/pmd/pmd-eclipse-plugin/issues/70): UnsupportedOperationException opening Rule Configuration
 *   [#76](https://github.com/pmd/pmd-eclipse-plugin/issues/76): Global rule management is saved even if cancelled
+*   [#1359](https://sourceforge.net/p/pmd/bugs/1359/): PMD violations in eclipse should be shown on editor by scrollbar
 
 ### External Contributions
 

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/ReviewCmdTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/ReviewCmdTest.java
@@ -35,14 +35,19 @@
 package net.sourceforge.pmd.eclipse.runtime.cmd;
 
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jdt.internal.core.search.IRestrictedAccessConstructorRequestor;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -52,6 +57,7 @@ import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.eclipse.EclipseUtils;
 import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
+import net.sourceforge.pmd.eclipse.runtime.PMDRuntimeConstants;
 import net.sourceforge.pmd.eclipse.runtime.properties.IProjectProperties;
 import net.sourceforge.pmd.eclipse.ui.actions.RuleSetUtil;
 
@@ -124,6 +130,17 @@ public class ReviewCmdTest {
         // We do not test PMD, only a non-empty report is enough
         Assert.assertNotNull(markers);
         Assert.assertTrue("Report size = " + markers.size(), markers.size() > 0);
+
+        // test the marker types - they should be problem markers...
+        final IFile sourceFile = this.testProject.getFile("/src/Test.java");
+        List<IMarker> imarkers = new ArrayList<>();
+        for (String markerType : PMDRuntimeConstants.RULE_MARKER_TYPES) {
+            imarkers.addAll(Arrays.asList(sourceFile.findMarkers(markerType, false, IResource.DEPTH_ONE)));
+        }
+        Assert.assertEquals(markers.get(sourceFile).size(), imarkers.size());
+        for (IMarker marker : imarkers) {
+            Assert.assertTrue(marker.isSubtypeOf(IMarker.PROBLEM));
+        }
     }
 
     /**

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/ReviewCmdTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/ReviewCmdTest.java
@@ -47,7 +47,6 @@ import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.jdt.internal.core.search.IRestrictedAccessConstructorRequestor;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;

--- a/net.sourceforge.pmd.eclipse.plugin/META-INF/MANIFEST.MF
+++ b/net.sourceforge.pmd.eclipse.plugin/META-INF/MANIFEST.MF
@@ -16,7 +16,8 @@ Require-Bundle: org.apache.commons.logging;bundle-version="1.0.4",
  org.eclipse.search,
  org.eclipse.help,
  org.eclipse.help.ui,
- org.eclipse.wst.xml.core
+ org.eclipse.wst.xml.core,
+ org.eclipse.ui.workbench.texteditor
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: %plugin.provider

--- a/net.sourceforge.pmd.eclipse.plugin/plugin.properties
+++ b/net.sourceforge.pmd.eclipse.plugin/plugin.properties
@@ -1,6 +1,12 @@
 # PMD Eclipse Plugin externalized strings
 
+marker.category = PMD Markers
 marker.pmd = PMD Marker
+marker.pmd.prio1 = PMD Marker (Prio 1)
+marker.pmd.prio2 = PMD Marker (Prio 2)
+marker.pmd.prio3 = PMD Marker (Prio 3)
+marker.pmd.prio4 = PMD Marker (Prio 4)
+marker.pmd.prio5 = PMD Marker (Prio 5)
 marker.task = PMD Task Marker
 marker.dfa = PMD DFA Marker
 

--- a/net.sourceforge.pmd.eclipse.plugin/plugin.xml
+++ b/net.sourceforge.pmd.eclipse.plugin/plugin.xml
@@ -24,7 +24,7 @@
 
  <extension
          id="pmdMarker1"
-         name="%marker.pmd"
+         name="%marker.pmd.prio1"
          point="org.eclipse.core.resources.markers">
       <super type="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></super>
       <persistent value="true"></persistent>
@@ -32,7 +32,7 @@
 
   <extension
          id="pmdMarker2"
-         name="%marker.pmd"
+         name="%marker.pmd.prio2"
          point="org.eclipse.core.resources.markers">
       <super type="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></super>
       <persistent value="true"></persistent>
@@ -40,7 +40,7 @@
 
   <extension
          id="pmdMarker3"
-         name="%marker.pmd"
+         name="%marker.pmd.prio3"
          point="org.eclipse.core.resources.markers">
       <super type="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></super>
       <persistent value="true"></persistent>
@@ -48,7 +48,7 @@
 
   <extension
          id="pmdMarker4"
-         name="%marker.pmd"
+         name="%marker.pmd.prio4"
          point="org.eclipse.core.resources.markers">
       <super type="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></super>
       <persistent value="true"></persistent>
@@ -56,11 +56,23 @@
 
   <extension
          id="pmdMarker5"
-         name="%marker.pmd"
+         name="%marker.pmd.prio5"
          point="org.eclipse.core.resources.markers">
       <super type="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></super>
-      <persistent value="true">  </persistent>
-      <attribute name="rulename">  </attribute>
+      <persistent value="true"></persistent>
+   </extension>
+
+   <extension point="org.eclipse.ui.ide.markerSupport">
+      <markerTypeCategory name="%marker.category">
+        <markerTypeReference id="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></markerTypeReference>
+        <markerTypeReference id="net.sourceforge.pmd.eclipse.plugin.pmdMarker1"></markerTypeReference>
+        <markerTypeReference id="net.sourceforge.pmd.eclipse.plugin.pmdMarker2"></markerTypeReference>
+        <markerTypeReference id="net.sourceforge.pmd.eclipse.plugin.pmdMarker3"></markerTypeReference>
+        <markerTypeReference id="net.sourceforge.pmd.eclipse.plugin.pmdMarker4"></markerTypeReference>
+        <markerTypeReference id="net.sourceforge.pmd.eclipse.plugin.pmdMarker5"></markerTypeReference>
+        <markerTypeReference id="net.sourceforge.pmd.eclipse.plugin.pmdTaskMarker"></markerTypeReference>
+        <markerTypeReference id="net.sourceforge.pmd.eclipse.plugin.pmdDFAMarker"></markerTypeReference>
+      </markerTypeCategory>
    </extension>
 
 <extension point="org.eclipse.ui.ide.markerImageProviders">

--- a/net.sourceforge.pmd.eclipse.plugin/plugin.xml
+++ b/net.sourceforge.pmd.eclipse.plugin/plugin.xml
@@ -17,7 +17,6 @@
          name="%marker.pmd"
          point="org.eclipse.core.resources.markers">
       <super type="org.eclipse.core.resources.textmarker"></super>
-      <super type="org.eclipse.core.resources.problemmarker"></super>
       <persistent value="true"></persistent>
       <attribute name="rulename"></attribute>
    </extension>
@@ -26,6 +25,7 @@
          id="pmdMarker1"
          name="%marker.pmd.prio1"
          point="org.eclipse.core.resources.markers">
+      <super type="org.eclipse.core.resources.problemmarker"></super>
       <super type="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></super>
       <persistent value="true"></persistent>
    </extension>
@@ -34,6 +34,7 @@
          id="pmdMarker2"
          name="%marker.pmd.prio2"
          point="org.eclipse.core.resources.markers">
+      <super type="org.eclipse.core.resources.problemmarker"></super>
       <super type="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></super>
       <persistent value="true"></persistent>
    </extension>
@@ -42,6 +43,7 @@
          id="pmdMarker3"
          name="%marker.pmd.prio3"
          point="org.eclipse.core.resources.markers">
+      <super type="org.eclipse.core.resources.problemmarker"></super>
       <super type="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></super>
       <persistent value="true"></persistent>
    </extension>
@@ -50,6 +52,7 @@
          id="pmdMarker4"
          name="%marker.pmd.prio4"
          point="org.eclipse.core.resources.markers">
+      <super type="org.eclipse.core.resources.problemmarker"></super>
       <super type="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></super>
       <persistent value="true"></persistent>
    </extension>
@@ -58,6 +61,7 @@
          id="pmdMarker5"
          name="%marker.pmd.prio5"
          point="org.eclipse.core.resources.markers">
+      <super type="org.eclipse.core.resources.problemmarker"></super>
       <super type="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></super>
       <persistent value="true"></persistent>
    </extension>
@@ -74,6 +78,159 @@
         <markerTypeReference id="net.sourceforge.pmd.eclipse.plugin.pmdDFAMarker"></markerTypeReference>
       </markerTypeCategory>
    </extension>
+
+    <extension
+        point="org.eclipse.ui.editors.annotationTypes">
+        <type
+            name="net.sourceforge.pmd.eclipse.plugin.annotation.prio1"
+            markerType="net.sourceforge.pmd.eclipse.plugin.pmdMarker1"/>
+        <type
+            name="net.sourceforge.pmd.eclipse.plugin.annotation.prio2"
+            markerType="net.sourceforge.pmd.eclipse.plugin.pmdMarker2"/>
+        <type
+            name="net.sourceforge.pmd.eclipse.plugin.annotation.prio3"
+            markerType="net.sourceforge.pmd.eclipse.plugin.pmdMarker3"/>
+        <type
+            name="net.sourceforge.pmd.eclipse.plugin.annotation.prio4"
+            markerType="net.sourceforge.pmd.eclipse.plugin.pmdMarker4"/>
+        <type
+            name="net.sourceforge.pmd.eclipse.plugin.annotation.prio5"
+            markerType="net.sourceforge.pmd.eclipse.plugin.pmdMarker5"/>
+    </extension>
+
+    <extension
+        point="org.eclipse.ui.editors.markerAnnotationSpecification">
+        <specification
+            annotationType="net.sourceforge.pmd.eclipse.plugin.annotation.prio1"
+            colorPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio1.color"
+            overviewRulerPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio1.overviewruler"
+            verticalRulerPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio1.verticalruler"
+            textPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio1.text"
+            label="PMD Violation Prio 1"
+            highlightPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio1.highlight"
+            colorPreferenceValue="255,0,0"
+            presentationLayer="5"
+            overviewRulerPreferenceValue="true"
+            verticalRulerPreferenceValue="true"
+            textPreferenceValue="false"
+            highlightPreferenceValue="true"
+            contributesToHeader="true"
+            showInNextPrevDropdownToolbarActionKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio1.dropdown"
+            showInNextPrevDropdownToolbarAction="true"
+            isGoToNextNavigationTargetKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio1.next"
+            isGoToNextNavigationTarget="true"
+            isGoToPreviousNavigationTargetKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio1.previous"
+            isGoToPreviousNavigationTarget="true"
+            icon="icons/markerP1.png"
+            annotationImageProvider="net.sourceforge.pmd.eclipse.ui.PMDMarkerImageProvider"
+            textStylePreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio1.text.style"
+            textStylePreferenceValue="BOX"
+            includeOnPreferencePage="true" />
+        <specification
+            annotationType="net.sourceforge.pmd.eclipse.plugin.annotation.prio2"
+            colorPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio2.color"
+            overviewRulerPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio2.overviewruler"
+            verticalRulerPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio2.verticalruler"
+            textPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio2.text"
+            label="PMD Violation Prio 2"
+            highlightPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio2.highlight"
+            colorPreferenceValue="0,255,255"
+            presentationLayer="5"
+            overviewRulerPreferenceValue="true"
+            verticalRulerPreferenceValue="true"
+            textPreferenceValue="false"
+            highlightPreferenceValue="true"
+            contributesToHeader="true"
+            showInNextPrevDropdownToolbarActionKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio2.dropdown"
+            showInNextPrevDropdownToolbarAction="true"
+            isGoToNextNavigationTargetKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio2.next"
+            isGoToNextNavigationTarget="true"
+            isGoToPreviousNavigationTargetKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio2.previous"
+            isGoToPreviousNavigationTarget="true"
+            icon="icons/markerP2.png"
+            annotationImageProvider="net.sourceforge.pmd.eclipse.ui.PMDMarkerImageProvider"
+            textStylePreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio2.text.style"
+            textStylePreferenceValue="BOX"
+            includeOnPreferencePage="true" />
+        <specification
+            annotationType="net.sourceforge.pmd.eclipse.plugin.annotation.prio3"
+            colorPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio3.color"
+            overviewRulerPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio3.overviewruler"
+            verticalRulerPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio3.verticalruler"
+            textPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio3.text"
+            label="PMD Violation Prio 3"
+            highlightPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio3.highlight"
+            colorPreferenceValue="0,255,0"
+            presentationLayer="4"
+            overviewRulerPreferenceValue="true"
+            verticalRulerPreferenceValue="true"
+            textPreferenceValue="false"
+            highlightPreferenceValue="true"
+            contributesToHeader="true"
+            showInNextPrevDropdownToolbarActionKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio3.dropdown"
+            showInNextPrevDropdownToolbarAction="true"
+            isGoToNextNavigationTargetKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio3.next"
+            isGoToNextNavigationTarget="true"
+            isGoToPreviousNavigationTargetKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio3.previous"
+            isGoToPreviousNavigationTarget="true"
+            icon="icons/markerP3.png"
+            annotationImageProvider="net.sourceforge.pmd.eclipse.ui.PMDMarkerImageProvider"
+            textStylePreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio3.text.style"
+            textStylePreferenceValue="BOX"
+            includeOnPreferencePage="true" />
+        <specification
+            annotationType="net.sourceforge.pmd.eclipse.plugin.annotation.prio4"
+            colorPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio4.color"
+            overviewRulerPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio4.overviewruler"
+            verticalRulerPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio4.verticalruler"
+            textPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio4.text"
+            label="PMD Violation Prio 4"
+            highlightPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio4.highlight"
+            colorPreferenceValue="255,0,255"
+            presentationLayer="4"
+            overviewRulerPreferenceValue="true"
+            verticalRulerPreferenceValue="true"
+            textPreferenceValue="false"
+            highlightPreferenceValue="true"
+            contributesToHeader="true"
+            showInNextPrevDropdownToolbarActionKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio4.dropdown"
+            showInNextPrevDropdownToolbarAction="true"
+            isGoToNextNavigationTargetKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio4.next"
+            isGoToNextNavigationTarget="true"
+            isGoToPreviousNavigationTargetKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio4.previous"
+            isGoToPreviousNavigationTarget="true"
+            icon="icons/markerP4.png"
+            annotationImageProvider="net.sourceforge.pmd.eclipse.ui.PMDMarkerImageProvider"
+            textStylePreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio4.text.style"
+            textStylePreferenceValue="BOX"
+            includeOnPreferencePage="true" />
+        <specification
+            annotationType="net.sourceforge.pmd.eclipse.plugin.annotation.prio5"
+            colorPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio5.color"
+            overviewRulerPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio5.overviewruler"
+            verticalRulerPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio5.verticalruler"
+            textPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio5.text"
+            label="PMD Violation Prio 5"
+            highlightPreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio5.highlight"
+            colorPreferenceValue="0,0,255"
+            presentationLayer="3"
+            overviewRulerPreferenceValue="true"
+            verticalRulerPreferenceValue="true"
+            textPreferenceValue="false"
+            highlightPreferenceValue="true"
+            contributesToHeader="true"
+            showInNextPrevDropdownToolbarActionKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio5.dropdown"
+            showInNextPrevDropdownToolbarAction="true"
+            isGoToNextNavigationTargetKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio5.next"
+            isGoToNextNavigationTarget="true"
+            isGoToPreviousNavigationTargetKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio5.previous"
+            isGoToPreviousNavigationTarget="true"
+            icon="icons/markerP5.png"
+            annotationImageProvider="net.sourceforge.pmd.eclipse.ui.PMDMarkerImageProvider"
+            textStylePreferenceKey="net.sourceforge.pmd.eclipse.plugin.annotation.prio5.text.style"
+            textStylePreferenceValue="BOX"
+            includeOnPreferencePage="true" />
+    </extension>
 
 <extension point="org.eclipse.ui.ide.markerImageProviders">
     <imageprovider

--- a/net.sourceforge.pmd.eclipse.plugin/plugin.xml
+++ b/net.sourceforge.pmd.eclipse.plugin/plugin.xml
@@ -232,46 +232,6 @@
             includeOnPreferencePage="true" />
     </extension>
 
-<extension point="org.eclipse.ui.ide.markerImageProviders">
-    <imageprovider
-          id="PMD.imageProvider1"
-          icon="icons/markerP1.png"
-          markertype="net.sourceforge.pmd.eclipse.plugin.pmdMarker1">
-    </imageprovider>
-</extension>
-
-<extension point="org.eclipse.ui.ide.markerImageProviders">
-    <imageprovider
-          id="PMD.imageProvider2"
-          icon="icons/markerP2.png"
-          markertype="net.sourceforge.pmd.eclipse.plugin.pmdMarker2">
-    </imageprovider>
-</extension>
-
-<extension point="org.eclipse.ui.ide.markerImageProviders">
-    <imageprovider
-          id="PMD.imageProvider3"
-          icon="icons/markerP3.png"
-          markertype="net.sourceforge.pmd.eclipse.plugin.pmdMarker3">
-    </imageprovider>
-</extension>
-
-<extension point="org.eclipse.ui.ide.markerImageProviders">
-    <imageprovider
-          id="PMD.imageProvider4"
-          icon="icons/markerP4.png"
-          markertype="net.sourceforge.pmd.eclipse.plugin.pmdMarker4">
-    </imageprovider>
-</extension>
-
-<extension point="org.eclipse.ui.ide.markerImageProviders">
-    <imageprovider
-          id="PMD.imageProvider5"
-          icon="icons/markerP5.png"
-          markertype="net.sourceforge.pmd.eclipse.plugin.pmdMarker5">
-    </imageprovider>
-</extension>
-
    <extension
          id="pmdTaskMarker"
          name="%marker.task"

--- a/net.sourceforge.pmd.eclipse.plugin/plugin.xml
+++ b/net.sourceforge.pmd.eclipse.plugin/plugin.xml
@@ -12,64 +12,53 @@
       </toc>
    </extension>
 
-<!--   original marker
    <extension
          id="pmdMarker"
          name="%marker.pmd"
          point="org.eclipse.core.resources.markers">
-      <super
-            type="org.eclipse.core.resources.problemmarker">
-      </super>
-      <persistent
-            value="true">
-      </persistent>
-      <attribute
-            name="rulename">
-      </attribute>
+      <super type="org.eclipse.core.resources.textmarker"></super>
+      <super type="org.eclipse.core.resources.problemmarker"></super>
+      <persistent value="true"></persistent>
+      <attribute name="rulename"></attribute>
    </extension>
--->
 
  <extension
          id="pmdMarker1"
          name="%marker.pmd"
          point="org.eclipse.core.resources.markers">
-      <super type="org.eclipse.core.resources.textmarker"></super>
-      <persistent value="true"> </persistent>
-      <attribute  name="rulename">  </attribute>
+      <super type="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></super>
+      <persistent value="true"></persistent>
    </extension>
 
   <extension
          id="pmdMarker2"
          name="%marker.pmd"
          point="org.eclipse.core.resources.markers">
-      <super type="org.eclipse.core.resources.textmarker"></super>
-      <persistent value="true">  </persistent>
-      <attribute name="rulename">  </attribute>
+      <super type="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></super>
+      <persistent value="true"></persistent>
    </extension>
 
   <extension
          id="pmdMarker3"
          name="%marker.pmd"
          point="org.eclipse.core.resources.markers">
-      <super type="org.eclipse.core.resources.textmarker"></super>
-      <persistent value="true">  </persistent>
-      <attribute name="rulename">  </attribute>
+      <super type="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></super>
+      <persistent value="true"></persistent>
    </extension>
 
   <extension
          id="pmdMarker4"
          name="%marker.pmd"
          point="org.eclipse.core.resources.markers">
-      <super type="org.eclipse.core.resources.textmarker"></super>
-      <persistent value="true">  </persistent>
-      <attribute name="rulename">  </attribute>
+      <super type="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></super>
+      <persistent value="true"></persistent>
    </extension>
 
   <extension
          id="pmdMarker5"
          name="%marker.pmd"
          point="org.eclipse.core.resources.markers">
-      <super type="org.eclipse.core.resources.textmarker"></super>
+      <super type="net.sourceforge.pmd.eclipse.plugin.pmdMarker"></super>
       <persistent value="true">  </persistent>
       <attribute name="rulename">  </attribute>
    </extension>

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/PMDPlugin.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/PMDPlugin.java
@@ -388,7 +388,7 @@ public class PMDPlugin extends AbstractUIPlugin {
      * @return the image descriptor
      */
     public static ImageDescriptor getImageDescriptor(String path) {
-        return AbstractUIPlugin.imageDescriptorFromPlugin("net.sourceforge.pmd.eclipse.plugin", path);
+        return AbstractUIPlugin.imageDescriptorFromPlugin(PLUGIN_ID, path);
     }
 
     /**

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/PMDRuntimeConstants.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/PMDRuntimeConstants.java
@@ -12,7 +12,7 @@ import net.sourceforge.pmd.properties.IntegerProperty;
  */
 public class PMDRuntimeConstants {
 
-    public static final String PMD_MARKER = PMDPlugin.PLUGIN_ID + ".pmdMarker"; // obsolete
+    public static final String PMD_MARKER = PMDPlugin.PLUGIN_ID + ".pmdMarker";
 
     public static final String PMD_MARKER_1 = PMDPlugin.PLUGIN_ID + ".pmdMarker1";
     public static final String PMD_MARKER_2 = PMDPlugin.PLUGIN_ID + ".pmdMarker2";

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
@@ -482,19 +482,16 @@ public class BaseVisitor {
     }
 
     public static String markerTypeFor(RuleViolation violation) {
-
-        int priorityId = violation.getRule().getPriority().getPriority();
-
-        switch (priorityId) {
-        case 1:
+        switch (violation.getRule().getPriority()) {
+        case HIGH:
             return PMDRuntimeConstants.PMD_MARKER_1;
-        case 2:
+        case MEDIUM_HIGH:
             return PMDRuntimeConstants.PMD_MARKER_2;
-        case 3:
+        case MEDIUM:
             return PMDRuntimeConstants.PMD_MARKER_3;
-        case 4:
+        case MEDIUM_LOW:
             return PMDRuntimeConstants.PMD_MARKER_4;
-        case 5:
+        case LOW:
             return PMDRuntimeConstants.PMD_MARKER_5;
         default:
             return PMDRuntimeConstants.PMD_MARKER;
@@ -647,35 +644,23 @@ public class BaseVisitor {
         info.add(PMDRuntimeConstants.KEY_MARKERATT_LINE2, violation.getEndLine());
         info.add(PMDRuntimeConstants.KEY_MARKERATT_RULENAME, rule.getName());
         info.add(PMDRuntimeConstants.KEY_MARKERATT_PRIORITY, rule.getPriority().getPriority());
+        info.add(IMarker.PRIORITY, IMarker.PRIORITY_NORMAL);
 
-        switch (rule.getPriority().getPriority()) {
-        case 1:
-            info.add(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
+        switch (rule.getPriority()) {
+        case HIGH:
+        case MEDIUM_HIGH:
             info.add(IMarker.SEVERITY,
                     projectProperties.violationsAsErrors() ? IMarker.SEVERITY_ERROR : IMarker.SEVERITY_WARNING);
             break;
-        case 2:
-            if (projectProperties.violationsAsErrors()) {
-                info.add(IMarker.SEVERITY, IMarker.SEVERITY_ERROR);
-            } else {
-                info.add(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
-                info.add(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
-            }
-            break;
 
-        case 5:
-            info.add(IMarker.SEVERITY, IMarker.SEVERITY_INFO);
-            break;
-
-        case 3:
-            info.add(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
+        case MEDIUM:
+        case MEDIUM_LOW:
             info.add(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
             break;
 
-        case 4:
+        case LOW:
         default:
-            info.add(IMarker.PRIORITY, IMarker.PRIORITY_HIGH);
-            info.add(IMarker.SEVERITY, IMarker.SEVERITY_WARNING);
+            info.add(IMarker.SEVERITY, IMarker.SEVERITY_INFO);
             break;
         }
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/PMDMarkerImageProvider.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/PMDMarkerImageProvider.java
@@ -1,0 +1,40 @@
+
+package net.sourceforge.pmd.eclipse.ui;
+
+import org.eclipse.jface.resource.ImageDescriptor;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.ui.texteditor.IAnnotationImageProvider;
+
+import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
+
+public class PMDMarkerImageProvider implements IAnnotationImageProvider {
+
+    @Override
+    public ImageDescriptor getImageDescriptor(String imageDescriptorId) {
+        return null;
+    }
+
+    @Override
+    public String getImageDescriptorId(Annotation annotation) {
+        return null;
+    }
+
+    @Override
+    public Image getManagedImage(Annotation annotation) {
+        PMDPlugin plugin = PMDPlugin.getDefault();
+        String type = annotation.getType();
+        if ("net.sourceforge.pmd.eclipse.plugin.annotation.prio1".equals(type)) {
+            return plugin.getImage(type, "icons/markerP1.png");
+        } else if ("net.sourceforge.pmd.eclipse.plugin.annotation.prio2".equals(type)) {
+            return plugin.getImage(type, "icons/markerP2.png");
+        } else if ("net.sourceforge.pmd.eclipse.plugin.annotation.prio3".equals(type)) {
+            return plugin.getImage(type, "icons/markerP3.png");
+        } else if ("net.sourceforge.pmd.eclipse.plugin.annotation.prio4".equals(type)) {
+            return plugin.getImage(type, "icons/markerP4.png");
+        } else if ("net.sourceforge.pmd.eclipse.plugin.annotation.prio5".equals(type)) {
+            return plugin.getImage(type, "icons/markerP5.png");
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
Now they appear in the problem view and
"violationsAsErrors" is working as expected.

Refs #54 

This is ~work in progress. Open issues:~
* marker icon is now the default problem icon (exclamation mark). the custom PMD icons are not used. Solved :heavy_check_mark: 
* When filtering in the problem view by types, the PMD Markers should be listed under the same super type. Solved :heavy_check_mark: 
