### PR TITLE
Fix #88: PMD is executed for all file types regardless of active rules

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -26,6 +26,7 @@ This is a minor release.
 *   [#76](https://github.com/pmd/pmd-eclipse-plugin/issues/76): Global rule management is saved even if cancelled
 *   [#78](https://github.com/pmd/pmd-eclipse-plugin/issues/78): Project properties cannot be loaded anymore
 *   [#86](https://github.com/pmd/pmd-eclipse-plugin/issues/86): Add Markers next to Scroll bar
+*   [#88](https://github.com/pmd/pmd-eclipse-plugin/issues/88): PMD is executed for all file types regardless of active rules
 *   [#1359](https://sourceforge.net/p/pmd/bugs/1359/): PMD violations in eclipse should be shown on editor by scrollbar
 
 ### External Contributions

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/resources/test.template
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/resources/test.template
@@ -9,6 +9,7 @@ public class Test {
 
     public void foo() {
         try {
+        // EmptyCatchBlock!!
         } catch (Exception e) {
 
         }

--- a/net.sourceforge.pmd.eclipse.plugin/messages.properties
+++ b/net.sourceforge.pmd.eclipse.plugin/messages.properties
@@ -30,6 +30,7 @@ preference.pmd.label.check_after_saving = Check code after saving
 preference.pmd.label.use_dfa = Enable dataflow anomaly analysis (experimental)
 preference.pmd.label.use_project_build_path = Enable using Java Project Build Path.  Disable if your Eclipse JVM version is incompatible with .class file versions.
 preference.pmd.label.max_violations_pfpr = Maximum reported violations per file per rule
+preference.pmd.label.determine_filetypes_automatically = Determine applicable file types automatically (based on rule languages)
 preference.pmd.tooltip.max_violations_pfpr = This helps limit report sizes and improves overall performance
 preference.pmd.message.invalid_numeric_value = Incorrect numeric value entered
 preference.pmd.label.review_pmd_style = Use PMD style (// NOPMD comment)

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
@@ -15,6 +15,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
@@ -72,6 +73,7 @@ public class BaseVisitor {
     private Map<IFile, Set<MarkerInfo2>> accumulator;
     // private PMDEngine pmdEngine;
     private RuleSets ruleSets;
+    private Set<String> fileExtensions;
     private int fileCount;
     private long pmdDuration;
     private IProjectProperties projectProperties;
@@ -225,6 +227,10 @@ public class BaseVisitor {
         this.ruleSets = ruleSets;
     }
 
+    public void setFileExtensions(Set<String> fileExtensions) {
+        this.fileExtensions = fileExtensions;
+    }
+
     /**
      * @return the number of files that has been processed
      */
@@ -262,6 +268,18 @@ public class BaseVisitor {
         IFile file = (IFile) resource.getAdapter(IFile.class);
         if (file == null || file.getFileExtension() == null) {
             return;
+        }
+
+        if (PMDPlugin.getDefault().loadPreferences().isDetermineFiletypesAutomatically()) {
+            if (fileExtensions != null) {
+                if (!fileExtensions.contains(file.getFileExtension().toLowerCase(Locale.ROOT))) {
+                    PMDPlugin.getDefault().logInformation("Skipping file " + file.getName() + " based on file extension");
+                    LOG.debug("Skipping file " + file.getName() + " based on file extension");
+                    return;
+                }
+            } else {
+                LOG.warn("Can't check for file extensions.");
+            }
         }
 
         Reader input = null;

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/IPreferences.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/IPreferences.java
@@ -29,6 +29,7 @@ public interface IPreferences {
     boolean PMD_CHECK_AFTER_SAVE_DEFAULT = false;
     boolean PMD_USE_CUSTOM_PRIORITY_NAMES_DEFAULT = true;
     int MAX_VIOLATIONS_PFPR_DEFAULT = 5;
+    boolean DETERMINE_FILETYPES_AUTOMATICALLY_DEFAULT = true;
     String REVIEW_ADDITIONAL_COMMENT_DEFAULT = "by {0} on {1}";
     boolean REVIEW_PMD_STYLE_ENABLED_DEFAULT = true;
     int MIN_TILE_SIZE_DEFAULT = 25;
@@ -142,6 +143,19 @@ public interface IPreferences {
      * @param maxViolationPerFilePerRule
      */
     void setMaxViolationsPerFilePerRule(int maxViolationPerFilePerRule);
+
+    /**
+     * If true: When checking, whether a given file should be analyzed by PMD, take
+     * the rule's language and the language's file extensions into account.
+     * @return
+     */
+    boolean isDetermineFiletypesAutomatically();
+
+    /**
+     * Sets whether the rule's language file extensions should be considered or not.
+     * @param determineFiletypesAutomatically
+     */
+    void setDetermineFiletypesAutomatically(boolean determineFiletypesAutomatically);
 
     /**
      * Get the review additional comment. This comment is a text appended to the

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/impl/PreferencesImpl.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/impl/PreferencesImpl.java
@@ -39,6 +39,7 @@ class PreferencesImpl implements IPreferences {
     private boolean checkAfterSaveEnabled;
     private boolean useCustomPriorityNames;
     private int maxViolationsPerFilePerRule;
+    private boolean determineFiletypesAutomatically;
     private String reviewAdditionalComment;
     private boolean reviewPmdStyleEnabled;
     private int minTileSize;
@@ -144,6 +145,16 @@ class PreferencesImpl implements IPreferences {
      */
     public void setMaxViolationsPerFilePerRule(int maxViolationPerFilePerRule) {
         this.maxViolationsPerFilePerRule = maxViolationPerFilePerRule;
+    }
+
+    @Override
+    public boolean isDetermineFiletypesAutomatically() {
+        return determineFiletypesAutomatically;
+    }
+
+    @Override
+    public void setDetermineFiletypesAutomatically(boolean determineFiletypesAutomatically) {
+        this.determineFiletypesAutomatically = determineFiletypesAutomatically;
     }
 
     /**

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/impl/PreferencesManagerImpl.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/impl/PreferencesManagerImpl.java
@@ -68,6 +68,7 @@ class PreferencesManagerImpl implements IPreferencesManager {
     private static final String PMD_VIOLATIONS_OUTLINE_ENABLED = PMDPlugin.PLUGIN_ID + ".pmd_outline_enabled";
     private static final String PMD_CHECK_AFTER_SAVE_ENABLED = PMDPlugin.PLUGIN_ID + ".pmd_check_after_save_enabled";
     private static final String MAX_VIOLATIONS_PFPR = PMDPlugin.PLUGIN_ID + ".max_violations_pfpr";
+    private static final String DETERMINE_FILETYPES_AUTOMATICALLY = PMDPlugin.PLUGIN_ID + ".determine_filetypes_automatically";
     private static final String REVIEW_ADDITIONAL_COMMENT = PMDPlugin.PLUGIN_ID + ".review_additional_comment";
     private static final String REVIEW_PMD_STYLE_ENABLED = PMDPlugin.PLUGIN_ID + ".review_pmd_style_enabled";
     private static final String PMD_USE_CUSTOM_PRIORITY_NAMES = PMDPlugin.PLUGIN_ID + ".use_custom_priority_names";
@@ -159,6 +160,7 @@ class PreferencesManagerImpl implements IPreferencesManager {
         loadCheckAfterSaveEnabled();
         loadUseCustomPriorityNames();
         loadMaxViolationsPerFilePerRule();
+        loadDetermineFiletypesAutomatically();
         loadReviewAdditionalComment();
         loadReviewPmdStyleEnabled();
         loadMinTileSize();
@@ -231,6 +233,7 @@ class PreferencesManagerImpl implements IPreferencesManager {
         storeCheckAfterSaveEnabled();
         storeUseCustomPriorityNames();
         storeMaxViolationsPerFilePerRule();
+        storeDetermineFiletypesAutomatically();
         storeReviewAdditionalComment();
         storeReviewPmdStyleEnabled();
         storeMinTileSize();
@@ -304,6 +307,11 @@ class PreferencesManagerImpl implements IPreferencesManager {
     private void loadMaxViolationsPerFilePerRule() {
         loadPreferencesStore.setDefault(MAX_VIOLATIONS_PFPR, IPreferences.MAX_VIOLATIONS_PFPR_DEFAULT);
         preferences.setMaxViolationsPerFilePerRule(loadPreferencesStore.getInt(MAX_VIOLATIONS_PFPR));
+    }
+    
+    private void loadDetermineFiletypesAutomatically() {
+        loadPreferencesStore.setDefault(DETERMINE_FILETYPES_AUTOMATICALLY, IPreferences.DETERMINE_FILETYPES_AUTOMATICALLY_DEFAULT);
+        preferences.setDetermineFiletypesAutomatically(loadPreferencesStore.getBoolean(DETERMINE_FILETYPES_AUTOMATICALLY));
     }
 
     private void loadReviewAdditionalComment() {
@@ -484,6 +492,10 @@ class PreferencesManagerImpl implements IPreferencesManager {
     
     private void storeMaxViolationsPerFilePerRule() {
         storePreferencesStore.setValue(MAX_VIOLATIONS_PFPR, preferences.getMaxViolationsPerFilePerRule());
+    }
+
+    private void storeDetermineFiletypesAutomatically() {
+        storePreferencesStore.setValue(DETERMINE_FILETYPES_AUTOMATICALLY, preferences.isDetermineFiletypesAutomatically());
     }
 
     private void storeReviewAdditionalComment() {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/nls/StringKeys.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/nls/StringKeys.java
@@ -41,6 +41,7 @@ public class StringKeys {
     public static final String PREF_GENERAL_LABEL_USE_DFA = "preference.pmd.label.use_dfa";
     public static final String PREF_GENERAL_LABEL_USE_PROJECT_BUILD_PATH = "preference.pmd.label.use_project_build_path";
     public static final String PREF_GENERAL_LABEL_MAX_VIOLATIONS_PFPR = "preference.pmd.label.max_violations_pfpr";
+    public static final String PREF_GENERAL_LABEL_DETERMINE_FILETYPES_AUTOMATICALLY = "preference.pmd.label.determine_filetypes_automatically";
     public static final String PREF_GENERAL_TOOLTIP_MAX_VIOLATIONS_PFPR = "preference.pmd.tooltip.max_violations_pfpr";
     public static final String PREF_GENERAL_MESSAGE_INVALID_NUMERIC_VALUE = "preference.pmd.message.invalid_numeric_value";
     public static final String PREF_GENERAL_REVIEW_PMD_STYLE = "preference.pmd.label.review_pmd_style";

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/GeneralPreferencesPage.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/GeneralPreferencesPage.java
@@ -100,6 +100,7 @@ public class GeneralPreferencesPage extends PreferencePage implements IWorkbench
     private TableViewer tableViewer;
     private IPreferences preferences;
     private BasicTableManager priorityTableMgr;
+    private Button determineFiletypesAutomatically;
 
     private Control[] nameFields;
 
@@ -165,6 +166,7 @@ public class GeneralPreferencesPage extends PreferencePage implements IWorkbench
         showViolationsOutlineViewBox = buildShowViolationOutlineBoxButton(group);
         useProjectBuildPath = buildUseProjectBuildPathButton(group);
         checkCodeOnSave = buildCheckCodeOnSaveButton(group);
+        determineFiletypesAutomatically = buildDetermineFiletypesAutomatically(group);
         Label separator = new Label(group, SWT.SEPARATOR | SWT.SHADOW_IN | SWT.HORIZONTAL);
         maxViolationsPerFilePerRule = buildMaxViolationsPerFilePerRuleText(group);
 
@@ -709,6 +711,13 @@ public class GeneralPreferencesPage extends PreferencePage implements IWorkbench
         return spinner;
     }
 
+    private Button buildDetermineFiletypesAutomatically(Composite viewGroup) {
+        Button button = new Button(viewGroup, SWT.CHECK);
+        button.setText(getMessage(StringKeys.PREF_GENERAL_LABEL_DETERMINE_FILETYPES_AUTOMATICALLY));
+        button.setSelection(preferences.isDetermineFiletypesAutomatically());
+        return button;
+    }
+
     /**
      * Build the check box for enabling PMD review style
      * 
@@ -752,6 +761,7 @@ public class GeneralPreferencesPage extends PreferencePage implements IWorkbench
         setSelection(useCustomPriorityNames, IPreferences.PMD_USE_CUSTOM_PRIORITY_NAMES_DEFAULT);
         setSelection(useProjectBuildPath, IPreferences.PROJECT_BUILD_PATH_ENABLED_DEFAULT);
         setSelection(reviewPmdStyleBox, IPreferences.REVIEW_PMD_STYLE_ENABLED_DEFAULT);
+        setSelection(determineFiletypesAutomatically, IPreferences.DETERMINE_FILETYPES_AUTOMATICALLY_DEFAULT);
 
         if (maxViolationsPerFilePerRule != null) {
             maxViolationsPerFilePerRule.setMinimum(IPreferences.MAX_VIOLATIONS_PFPR_DEFAULT);
@@ -884,6 +894,10 @@ public class GeneralPreferencesPage extends PreferencePage implements IWorkbench
         if (maxViolationsPerFilePerRule != null) {
             preferences
                     .setMaxViolationsPerFilePerRule(Integer.valueOf(maxViolationsPerFilePerRule.getText()).intValue());
+        }
+
+        if (determineFiletypesAutomatically != null) {
+            preferences.setDetermineFiletypesAutomatically(determineFiletypesAutomatically.getSelection());
         }
 
         if (reviewPmdStyleBox != null) {


### PR DESCRIPTION
Fixes #88 

- [x] Add new configuration option: "Determine applicable file types automatically" under PMD preferences
- [x] Determine all languages used in the ruleset (similar to PMD.getApplicableLanguages())
- [x] Adjust BaseVisitor.reviewResource() to only execute PMD for files with matching extension
- [x] Unit Test
