### PR TITLE
Show rule name im marker tooltip and provide marker properties page

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -13,7 +13,13 @@ This is a minor release.
 
 ### New and noteworthy
 
+*   PMD specific marker property page: This version adds a PMD specific property page to the
+    marker properties which shows more information from the rule violation and rule itself.
+    For more information, see [Marker Property Page (wiki)](https://github.com/pmd/pmd-eclipse-plugin/wiki/Marker-Property-Page).
+
 ### Fixed Issues
+
+*   [#84](https://github.com/pmd/pmd-eclipse-plugin/issues/84): Rule Name in Tooltip
 
 ### API Changes
 

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/ReviewCmdTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/ReviewCmdTest.java
@@ -112,8 +112,8 @@ public class ReviewCmdTest {
         Assert.assertEquals(markers.get(sourceFile).size(), imarkers.size());
         for (IMarker marker : imarkers) {
             Assert.assertTrue(marker.isSubtypeOf(IMarker.PROBLEM));
-            Assert.assertTrue(marker.getAttribute(IMarker.MESSAGE, "")
-                    .startsWith(marker.getAttribute(PMDRuntimeConstants.KEY_MARKERATT_RULENAME, "missing rule name")));
+            Assert.assertTrue(((String) marker.getAttribute(IMarker.MESSAGE))
+                    .startsWith((String) marker.getAttribute(PMDRuntimeConstants.KEY_MARKERATT_RULENAME)));
         }
     }
 

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/ReviewCmdTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/ReviewCmdTest.java
@@ -112,6 +112,8 @@ public class ReviewCmdTest {
         Assert.assertEquals(markers.get(sourceFile).size(), imarkers.size());
         for (IMarker marker : imarkers) {
             Assert.assertTrue(marker.isSubtypeOf(IMarker.PROBLEM));
+            Assert.assertTrue(marker.getAttribute(IMarker.MESSAGE, "")
+                    .startsWith(marker.getAttribute(PMDRuntimeConstants.KEY_MARKERATT_RULENAME, "missing rule name")));
         }
     }
 

--- a/net.sourceforge.pmd.eclipse.plugin/messages.properties
+++ b/net.sourceforge.pmd.eclipse.plugin/messages.properties
@@ -13,6 +13,14 @@ property.button.include_derived_files = Include derived files
 property.button.full_build_enabled = Full build enabled
 property.button.violations_as_errors = Handle high priority violations as Eclipse errors
 
+# Marker Property Page
+markerPropertyPage.label.rulename = Rule:
+markerPropertyPage.label.category = Category:
+markerPropertyPage.label.priority = Priority:
+markerPropertyPage.label.message = Message:
+markerPropertyPage.label.description = Description:
+markerPropertyPage.label.externalInfoUrl = External Info URL:
+
 # General preferences page
 preference.pmd.header = PMD-Plugin Options
 preference.pmd.title = PMD General Preferences

--- a/net.sourceforge.pmd.eclipse.plugin/nl/fr/messages.properties
+++ b/net.sourceforge.pmd.eclipse.plugin/nl/fr/messages.properties
@@ -13,6 +13,14 @@ property.button.include_derived_files = Inclure les fichiers dérivés
 property.button.full_build_enabled = Full build enabled
 property.button.violations_as_errors = Traiter les violations de haute priorité comme des erreurs d'Eclipse
 
+# Marker Property Page
+markerPropertyPage.label.rulename = Règle:
+markerPropertyPage.label.category = Catégorie:
+markerPropertyPage.label.priority = Priorité:
+markerPropertyPage.label.message = Message:
+markerPropertyPage.label.description = Description:
+markerPropertyPage.label.externalInfoUrl = URL d'information externe:
+
 # General preferences page
 preference.pmd.header = Préférences Générales PMD
 preference.pmd.title = Préférences Générales PMD

--- a/net.sourceforge.pmd.eclipse.plugin/plugin.xml
+++ b/net.sourceforge.pmd.eclipse.plugin/plugin.xml
@@ -359,6 +359,22 @@
             class="net.sourceforge.pmd.eclipse.ui.properties.PMDProjectPropertyPage"
             id="net.sourceforge.pmd.eclipse.ui.properties.pmdPropertyPage">
       </page>
+      <page
+            adaptable="true"
+            class="net.sourceforge.pmd.eclipse.ui.properties.PMDMarkerPropertyPage"
+            id="net.sourceforge.pmd.eclipse.ui.properties.markerPropertyPage"
+            name="PMD Marker"
+            nameFilter="*"
+            objectClass="org.eclipse.core.resources.IMarker">
+         <enabledWhen>
+            <adapt
+                  type="org.eclipse.core.resources.IMarker">
+               <test
+                     property="net.sourceforge.pmd.eclipse.plugin.isPMDMarker">
+               </test>
+            </adapt>
+         </enabledWhen>
+      </page>
    </extension>
 
    <extension
@@ -802,6 +818,16 @@
                uri="platform:/plugin/net.sourceforge.pmd.eclipse.plugin/rule-tests_1_0_0.xsd">
          </public>
       </catalogContribution>
+   </extension>
+   <extension
+         point="org.eclipse.core.expressions.propertyTesters">
+      <propertyTester
+            class="net.sourceforge.pmd.eclipse.ui.properties.MarkerPropertyTester"
+            id="net.sourceforge.pmd.eclipse.isPMDMarker"
+            namespace="net.sourceforge.pmd.eclipse.plugin"
+            properties="isPMDMarker"
+            type="org.eclipse.core.resources.IMarker">
+      </propertyTester>
    </extension>
 
 </plugin>

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/PMDRuntimeConstants.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/PMDRuntimeConstants.java
@@ -41,6 +41,11 @@ public class PMDRuntimeConstants {
     public static final String KEY_MARKERATT_LINE2 = "line2";
     public static final String KEY_MARKERATT_VARIABLE = "variable";
     public static final String KEY_MARKERATT_METHODNAME = "method";
+    /**
+     * The message from the rule violation. This is additionally here, since IMarker.MESSAGE will
+     * contain both rule name + message.
+     */
+    public static final String KEY_MARKERATT_MESSAGE = "pmd_message";
 
     public static final String PLUGIN_STYLE_REVIEW_COMMENT = "// @PMD:REVIEWED:";
     public static final String PMD_STYLE_REVIEW_COMMENT = "// NOPMD";

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
@@ -630,6 +630,7 @@ public class BaseVisitor {
         MarkerInfo2 info = new MarkerInfo2(type, 7);
 
         info.add(IMarker.MESSAGE, rule.getName() + ": " + violation.getDescription());
+        info.add(PMDRuntimeConstants.KEY_MARKERATT_MESSAGE, violation.getDescription());
         info.add(IMarker.LINE_NUMBER, violation.getBeginLine());
         info.add(PMDRuntimeConstants.KEY_MARKERATT_LINE2, violation.getEndLine());
         info.add(PMDRuntimeConstants.KEY_MARKERATT_RULENAME, rule.getName());

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
@@ -629,7 +629,7 @@ public class BaseVisitor {
 
         MarkerInfo2 info = new MarkerInfo2(type, 7);
 
-        info.add(IMarker.MESSAGE, violation.getDescription());
+        info.add(IMarker.MESSAGE, rule.getName() + ": " + violation.getDescription());
         info.add(IMarker.LINE_NUMBER, violation.getBeginLine());
         info.add(PMDRuntimeConstants.KEY_MARKERATT_LINE2, violation.getEndLine());
         info.add(PMDRuntimeConstants.KEY_MARKERATT_RULENAME, rule.getName());

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/MarkerPropertyTester.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/MarkerPropertyTester.java
@@ -1,0 +1,30 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.eclipse.ui.properties;
+
+import org.eclipse.core.expressions.PropertyTester;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
+
+import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
+
+public class MarkerPropertyTester extends PropertyTester {
+    @Override
+    public boolean test(Object receiver, String property, Object[] args, Object expectedValue) {
+        if (!(receiver instanceof IMarker)) {
+            return false;
+        }
+
+        IMarker marker = (IMarker) receiver;
+
+        try {
+            return marker.getType().startsWith(PMDPlugin.PLUGIN_ID);
+        } catch (CoreException e) {
+            PMDPlugin.getDefault().logError(e.getMessage(), e);
+        }
+        return false;
+    }
+
+}

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/PMDMarkerPropertyPage.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/PMDMarkerPropertyPage.java
@@ -28,6 +28,7 @@ import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
 import net.sourceforge.pmd.eclipse.runtime.PMDRuntimeConstants;
 import net.sourceforge.pmd.eclipse.runtime.builder.MarkerUtil;
+import net.sourceforge.pmd.eclipse.ui.nls.StringTable;
 
 public class PMDMarkerPropertyPage extends PropertyPage {
 
@@ -46,23 +47,25 @@ public class PMDMarkerPropertyPage extends PropertyPage {
         Rule rule = PMDPlugin.getDefault().getPreferencesManager().getRuleSet()
                 .getRuleByName(MarkerUtil.ruleNameFor(marker));
 
+        StringTable messages = PMDPlugin.getDefault().getStringTable();
+
         try {
-            addLabel(composite, "Rule:");
+            addLabel(composite, messages.getString("markerPropertyPage.label.rulename"));
             addText(composite, rule.getName());
 
-            addLabel(composite, "Category:");
+            addLabel(composite, messages.getString("markerPropertyPage.label.category"));
             addText(composite, rule.getRuleSetName());
 
-            addLabel(composite, "Priority:");
+            addLabel(composite, messages.getString("markerPropertyPage.label.priority"));
             addText(composite, rule.getPriority().name());
 
-            addLabel(composite, "Message:");
+            addLabel(composite, messages.getString("markerPropertyPage.label.message"));
             addText(composite, getViolationMessage(marker));
 
-            addLabel(composite, "Description:", 2);
+            addLabel(composite, messages.getString("markerPropertyPage.label.description"), 2);
             addDescription(composite, rule);
 
-            addLabel(composite, "External URL Info:");
+            addLabel(composite, messages.getString("markerPropertyPage.label.externalInfoUrl"));
             addLink(composite, rule);
         } catch (CoreException e) {
             PMDPlugin.getDefault().logError(e.getMessage(), e);

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/PMDMarkerPropertyPage.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/PMDMarkerPropertyPage.java
@@ -1,0 +1,133 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.eclipse.ui.properties;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.events.SelectionListener;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.layout.GridLayout;
+import org.eclipse.swt.widgets.Composite;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Link;
+import org.eclipse.swt.widgets.Text;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.browser.IWebBrowser;
+import org.eclipse.ui.dialogs.PropertyPage;
+
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
+import net.sourceforge.pmd.eclipse.runtime.PMDRuntimeConstants;
+import net.sourceforge.pmd.eclipse.runtime.builder.MarkerUtil;
+
+public class PMDMarkerPropertyPage extends PropertyPage {
+
+    @Override
+    protected Control createContents(Composite parent) {
+        noDefaultAndApplyButton();
+
+        Composite composite = new Composite(parent, SWT.NULL);
+        composite.setLayoutData(new GridData(SWT.FILL, SWT.FILL, true, true));
+        GridLayout layout = new GridLayout();
+        layout.numColumns = 2;
+        composite.setLayout(layout);
+
+
+        IMarker marker = (IMarker) getElement();
+        Rule rule = PMDPlugin.getDefault().getPreferencesManager().getRuleSet()
+                .getRuleByName(MarkerUtil.ruleNameFor(marker));
+
+        try {
+            addLabel(composite, "Rule:");
+            addText(composite, rule.getName());
+
+            addLabel(composite, "Category:");
+            addText(composite, rule.getRuleSetName());
+
+            addLabel(composite, "Priority:");
+            addText(composite, rule.getPriority().name());
+
+            addLabel(composite, "Message:");
+            addText(composite, getViolationMessage(marker));
+
+            addLabel(composite, "Description:", 2);
+            addDescription(composite, rule);
+
+            addLabel(composite, "External URL Info:");
+            addLink(composite, rule);
+        } catch (CoreException e) {
+            PMDPlugin.getDefault().logError(e.getMessage(), e);
+        }
+
+        return composite;
+    }
+
+    private String getViolationMessage(IMarker marker) throws CoreException {
+        String defaultMessage = marker.getAttribute(IMarker.MESSAGE, "");
+        return marker.getAttribute(PMDRuntimeConstants.KEY_MARKERATT_MESSAGE, defaultMessage);
+    }
+
+    private void addDescription(Composite composite, Rule rule) {
+        Text descriptionText = new Text(composite, SWT.MULTI | SWT.WRAP | SWT.READ_ONLY);
+        GridData gridData = new GridData(GridData.FILL_BOTH);
+        gridData.horizontalSpan = 2;
+        gridData.heightHint = 50;
+        descriptionText.setLayoutData(gridData);
+        descriptionText.setText(rule.getDescription());
+    }
+
+    private void addLink(Composite composite, Rule rule) {
+        Link link = new Link(composite, SWT.NONE);
+        link.setText("<a href=\"" + rule.getExternalInfoUrl() + "\">" + rule.getExternalInfoUrl() + "</a>");
+        link.addSelectionListener(new LinkClickListener());
+    }
+
+    private void addText(Composite parent, String value) {
+        Text text = new Text(parent, SWT.READ_ONLY | SWT.SINGLE);
+        text.setBackground(parent.getBackground());
+        GridData gridData = new GridData(GridData.FILL_HORIZONTAL);
+        text.setLayoutData(gridData);
+        text.setText(value);
+    }
+
+    private void addLabel(Composite parent, String label) {
+        addLabel(parent, label, 1);
+    }
+
+    private void addLabel(Composite parent, String text, int columnSpan) {
+        Label label = new Label(parent, SWT.NONE);
+        if (columnSpan > 1) {
+            GridData gridData = new GridData();
+            gridData.horizontalSpan = columnSpan;
+            label.setLayoutData(gridData);
+        }
+        label.setText(text);
+    }
+
+    private static final class LinkClickListener implements SelectionListener {
+        @Override
+        public void widgetSelected(SelectionEvent e) {
+            try {
+                URL url = new URL(e.text);
+                IWebBrowser browser = PlatformUI.getWorkbench().getBrowserSupport().getExternalBrowser();
+                browser.openURL(url);
+            } catch (MalformedURLException | PartInitException e1) {
+                PMDPlugin.getDefault().logError(e1.getMessage(), e1);
+            }
+        }
+
+        @Override
+        public void widgetDefaultSelected(SelectionEvent e) {
+            widgetSelected(e);
+        }
+    }
+}


### PR DESCRIPTION
This adds the rulename in front of the violation message, so that it's easier to see, from which rule the PMD marker originated.

Additionally, a new marker properties page for PMD markers is added.
See https://github.com/pmd/pmd-eclipse-plugin/wiki/Marker-Property-Page
