### PR TITLE
Support external configuration changes

### DIFF
--- a/net.sourceforge.pmd.eclipse.plugin.test/META-INF/MANIFEST.MF
+++ b/net.sourceforge.pmd.eclipse.plugin.test/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Version: 4.14.0.qualifier
 Bundle-Name: PMD Test Plugin
-Bundle-SymbolicName: net.sourceforge.pmd.eclipse.plugin.test;singleton=true
+Bundle-SymbolicName: net.sourceforge.pmd.eclipse.plugin.test;singleton:=true
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: PMD Development Team
 Require-Bundle: org.eclipse.ui,
@@ -17,3 +17,4 @@ Require-Bundle: org.eclipse.ui,
 Import-Package: ch.qos.logback.classic,
  org.slf4j
 Bundle-Activator: net.sourceforge.pmd.eclipse.internal.TestActivator
+Bundle-ActivationPolicy: lazy

--- a/net.sourceforge.pmd.eclipse.plugin.test/pom.xml
+++ b/net.sourceforge.pmd.eclipse.plugin.test/pom.xml
@@ -20,6 +20,7 @@
         <configuration>
             <useUIHarness>true</useUIHarness>
             <showEclipseLog>true</showEclipseLog>
+            <trimStackTrace>false</trimStackTrace>
         </configuration>
       </plugin>
       <plugin>

--- a/net.sourceforge.pmd.eclipse.plugin.test/pom.xml
+++ b/net.sourceforge.pmd.eclipse.plugin.test/pom.xml
@@ -19,6 +19,7 @@
         <artifactId>tycho-surefire-plugin</artifactId>
         <configuration>
             <useUIHarness>true</useUIHarness>
+            <showEclipseLog>true</showEclipseLog>
         </configuration>
       </plugin>
       <plugin>

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/internal/ResourceUtil.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/internal/ResourceUtil.java
@@ -1,0 +1,29 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.eclipse.internal;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class ResourceUtil {
+    private ResourceUtil() {
+        // utility
+    }
+
+    public static void copyResource(Object context, String resource, File target) throws IOException {
+        try (FileOutputStream out = new FileOutputStream(target);
+             InputStream in = context.getClass().getResourceAsStream(resource)) {
+            int count;
+            byte[] buffer = new byte[8192];
+            count = in.read(buffer);
+            while (count > -1) {
+                out.write(buffer, 0, count);
+                count = in.read(buffer);
+            }
+        }
+    }
+}

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/impl/ChangeGlobalRuleSetExternallyTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/impl/ChangeGlobalRuleSetExternallyTest.java
@@ -1,0 +1,43 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.eclipse.runtime.preferences.impl;
+
+import java.io.File;
+
+import org.eclipse.core.runtime.IPath;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sourceforge.pmd.RuleSet;
+import net.sourceforge.pmd.eclipse.internal.ResourceUtil;
+import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
+import net.sourceforge.pmd.eclipse.runtime.preferences.IPreferencesManager;
+
+
+public class ChangeGlobalRuleSetExternallyTest {
+
+    @Test
+    public void changeRuleSetExternally() throws Exception {
+        IPreferencesManager preferencesManager = PMDPlugin.getDefault().getPreferencesManager();
+        RuleSet ruleSet = preferencesManager.getRuleSet();
+        int numberOfRules = ruleSet.size();
+        Assert.assertTrue(numberOfRules > 1);
+        
+        // Now change the ruleset on disk
+        IPath ruleSetFile = PMDPlugin.getDefault().getStateLocation().append("/ruleset.xml");
+        File ruleSetRealFile = ruleSetFile.toFile();
+        ResourceUtil.copyResource(this, "test-ruleset.xml", ruleSetRealFile);
+
+        RuleSet ruleSet2 = preferencesManager.getRuleSet();
+        Assert.assertEquals(1, ruleSet2.size());
+    }
+
+    @After
+    public void cleanup() {
+        IPreferencesManager preferencesManager = PMDPlugin.getDefault().getPreferencesManager();
+        preferencesManager.setRuleSet(preferencesManager.getDefaultRuleSet());
+    }
+}

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/impl/PreferencesChangedExternallyTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/impl/PreferencesChangedExternallyTest.java
@@ -1,0 +1,42 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.eclipse.runtime.preferences.impl;
+
+import java.io.File;
+
+import org.eclipse.core.resources.IWorkspaceRoot;
+import org.eclipse.core.resources.ResourcesPlugin;
+import org.eclipse.core.runtime.IPath;
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sourceforge.pmd.eclipse.internal.ResourceUtil;
+import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
+import net.sourceforge.pmd.eclipse.runtime.preferences.IPreferences;
+import net.sourceforge.pmd.eclipse.runtime.preferences.IPreferencesManager;
+
+public class PreferencesChangedExternallyTest {
+
+    @Test
+    public void changePreferenceExternally() throws Exception {
+        IPreferencesManager preferencesManager = PMDPlugin.getDefault().getPreferencesManager();
+        IPreferences preferences = preferencesManager.loadPreferences();
+        try {
+            Assert.assertTrue(preferences.isActive("AbstractClassWithoutAbstractMethod"));
+    
+            IWorkspaceRoot workspaceRoot = ResourcesPlugin.getWorkspace().getRoot();
+            IPath prefsFile = workspaceRoot.getLocation().append(".metadata/.plugins/org.eclipse.core.runtime/.settings/net.sourceforge.pmd.eclipse.plugin.prefs");
+            File prefsFileReal = prefsFile.toFile();
+            ResourceUtil.copyResource(this, "pmd.prefs", prefsFileReal);
+    
+            IPreferences preferences2 = preferencesManager.loadPreferences();
+            Assert.assertFalse(preferences2.isActive("AbstractClassWithoutAbstractMethod"));
+            Assert.assertTrue(preferences2.isActive("DoNotCallSystemExit"));
+            Assert.assertNotSame(preferences, preferences2);
+        } finally {
+            preferencesManager.storePreferences(preferences);
+        }
+    }
+}

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/ProjectPropertiesModelTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/ProjectPropertiesModelTest.java
@@ -44,9 +44,6 @@ public class ProjectPropertiesModelTest {
     private IProject testProject;
     private RuleSet initialPluginRuleSet;
 
-    /**
-     * @see junit.framework.TestCase#setUp()
-     */
     @Before
     public void setUp() throws Exception {
 

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/ExternalRuleSetFileTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/ExternalRuleSetFileTest.java
@@ -11,51 +11,58 @@ import java.io.InputStream;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
 import org.junit.After;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.eclipse.EclipseUtils;
 import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
 import net.sourceforge.pmd.eclipse.runtime.cmd.BuildProjectCommand;
+import net.sourceforge.pmd.eclipse.runtime.cmd.JobCommandProcessor;
 import net.sourceforge.pmd.eclipse.runtime.properties.IProjectProperties;
 import net.sourceforge.pmd.eclipse.runtime.properties.IProjectPropertiesManager;
 import net.sourceforge.pmd.eclipse.ui.actions.RuleSetUtil;
 
 public class ExternalRuleSetFileTest {
+    private static final Logger LOG = LoggerFactory.getLogger(ExternalRuleSetFileTest.class);
+
     private static final String PROJECT_RULESET_FILENAME = ".pmd-ruleset.xml";
 
     private IProject testProject;
 
 
-    @Before
-    public void setUp() throws Exception {
-        // 1. Create a Java project
-        this.testProject = EclipseUtils.createJavaProject("PMDTestProject");
-        Assert.assertTrue("A test project cannot be created; the tests cannot be performed.",
-                this.testProject != null && this.testProject.exists() && this.testProject.isAccessible());
+    private void setUpProject(String projectName) {
+        try {
+            this.testProject = EclipseUtils.createJavaProject(projectName);
+            Assert.assertTrue("A test project cannot be created; the tests cannot be performed.",
+                    this.testProject != null && this.testProject.exists() && this.testProject.isAccessible());
+        } catch (CoreException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @After
     public void tearDown() throws Exception {
         try {
-            // 1. Delete the test project
             if (this.testProject != null) {
                 if (this.testProject.exists() && this.testProject.isAccessible()) {
                     this.testProject.delete(true, true, null);
                     this.testProject = null;
                 }
             }
-        } catch (final Exception e) {
-            System.out.println("Exception " + e.getClass().getName() + " when tearing down. Ignored.");
+        } catch (CoreException e) {
+            throw new RuntimeException(e);
         }
     }
 
     @Test
     public void changedExternalRulesetShouldBeReloaded() throws Exception {
+        setUpProject("ExternalRulesetTest");
         InputStream ruleset1 = ExternalRuleSetFileTest.class.getResourceAsStream("ruleset1.xml");
 
         // create the ruleset file in the project
@@ -105,6 +112,7 @@ public class ExternalRuleSetFileTest {
 
     @Test
     public void externallyChangedProjectPropertiesShouldBeReloaded() throws Exception {
+        setUpProject("ProjectPropertiesChanged");
         // configure the project to use PMD
         final UpdateProjectPropertiesCmd cmd = new UpdateProjectPropertiesCmd();
         cmd.setPmdEnabled(true);
@@ -120,6 +128,7 @@ public class ExternalRuleSetFileTest {
             rebuildCmd.setProject(this.testProject);
             rebuildCmd.setUserInitiated(true);
             rebuildCmd.execute();
+            JobCommandProcessor.getInstance().waitCommandToFinish(null);
         }
 
 
@@ -150,13 +159,14 @@ public class ExternalRuleSetFileTest {
         }
         File projectPropertiesFileReal = projectPropertiesFile.getLocation().toFile();
         copyResource("pmd-properties", projectPropertiesFileReal);
+        LOG.debug("Overwritten {}", projectPropertiesFile);
 
         // the model is not updated yet...
         Assert.assertEquals(numberOfRules, model.getProjectRuleSet().getRules().size());
         // but it will be when requesting the project properties again
         final IProjectProperties model2 = mgr.loadProjectProperties(testProject);
         // the file and the ruleset have changed, this should be detected
-        Assert.assertTrue(model.isNeedRebuild());
+        Assert.assertTrue(model2.isNeedRebuild());
         // the new rule set should be active now
         Assert.assertEquals(1, model2.getProjectRuleSet().getRules().size());
         // the model is still cached, but the rules are updated
@@ -167,6 +177,7 @@ public class ExternalRuleSetFileTest {
         rebuildCmd.setProject(this.testProject);
         rebuildCmd.setUserInitiated(true);
         rebuildCmd.execute();
+        JobCommandProcessor.getInstance().waitCommandToFinish(null);
         // need rebuild flag should be reset now
         Assert.assertFalse(model.isNeedRebuild());
     }

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/ExternalRuleSetFileTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/ExternalRuleSetFileTest.java
@@ -82,6 +82,9 @@ public class ExternalRuleSetFileTest {
         RuleSet projectRuleSet = model.getProjectRuleSet();
         Assert.assertEquals(1, projectRuleSet.getRules().size());
 
+        // we need to wait a bit, so that the modified timestamp of the file becomes actually different
+        Thread.sleep(100);
+
         // now let's change the ruleSetFile without eclipse knowing about it ("externally")
         File ruleSetFileReal = ruleSetFile.getLocation().toFile();
         try (FileOutputStream out = new FileOutputStream(ruleSetFileReal);

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/ExternalRuleSetFileTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/ExternalRuleSetFileTest.java
@@ -92,9 +92,6 @@ public class ExternalRuleSetFileTest {
         RuleSet projectRuleSet = model.getProjectRuleSet();
         Assert.assertEquals(1, projectRuleSet.getRules().size());
 
-        // we need to wait a bit, so that the modified timestamp of the file becomes actually different
-        Thread.sleep(100);
-
         // now let's change the ruleSetFile without eclipse knowing about it ("externally")
         File ruleSetFileReal = ruleSetFile.getLocation().toFile();
         copyResource("ruleset2.xml", ruleSetFileReal);
@@ -148,9 +145,6 @@ public class ExternalRuleSetFileTest {
         }
         File ruleSetFileReal = ruleSetFile.getLocation().toFile();
         copyResource("ruleset1.xml", ruleSetFileReal);
-
-        // we need to wait a bit, so that the modified timestamp of the file becomes actually different
-        Thread.sleep(100);
 
         // now overwrite and change the .pmd project properties without eclipse knowing about it ("externally")
         IFile projectPropertiesFile = this.testProject.getFile(".pmd");

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/ExternalRuleSetFileTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/ExternalRuleSetFileTest.java
@@ -1,0 +1,108 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.eclipse.ui.properties;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import net.sourceforge.pmd.RuleSet;
+import net.sourceforge.pmd.RuleSets;
+import net.sourceforge.pmd.eclipse.EclipseUtils;
+import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
+import net.sourceforge.pmd.eclipse.runtime.properties.IProjectProperties;
+import net.sourceforge.pmd.eclipse.runtime.properties.IProjectPropertiesManager;
+import net.sourceforge.pmd.eclipse.ui.actions.RuleSetUtil;
+
+public class ExternalRuleSetFileTest {
+    private IProject testProject;
+
+    @Before
+    public void setUp() throws Exception {
+        // 1. Create a Java project
+        this.testProject = EclipseUtils.createJavaProject("PMDTestProject");
+        Assert.assertTrue("A test project cannot be created; the tests cannot be performed.",
+                this.testProject != null && this.testProject.exists() && this.testProject.isAccessible());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        try {
+            // 1. Delete the test project
+            if (this.testProject != null) {
+                if (this.testProject.exists() && this.testProject.isAccessible()) {
+                    this.testProject.delete(true, true, null);
+                    this.testProject = null;
+                }
+            }
+        } catch (final Exception e) {
+            System.out.println("Exception " + e.getClass().getName() + " when tearing down. Ignored.");
+        }
+    }
+
+    @Test
+    public void changedExternalRulesetShouldBeReloaded() throws Exception {
+        String ruleSetFileName = ".pmd-ruleset.xml";
+        InputStream ruleset1 = ExternalRuleSetFileTest.class.getResourceAsStream("ruleset1.xml");
+
+
+        // create the ruleset file in the project
+        IFile ruleSetFile = this.testProject.getFile(ruleSetFileName);
+        if (ruleSetFile.exists()) {
+            Assert.fail("File " + ruleSetFileName + " already exists!");
+        }
+        try {
+            ruleSetFile.create(ruleset1, true, null);
+        } finally {
+            ruleset1.close();
+        }
+
+        // configure the project to use this
+        final UpdateProjectPropertiesCmd cmd = new UpdateProjectPropertiesCmd();
+        cmd.setPmdEnabled(true);
+        cmd.setProject(this.testProject);
+        cmd.setProjectWorkingSet(null);
+        cmd.setProjectRuleSets(new RuleSets(RuleSetUtil.newEmpty("empty", "empty")));
+        cmd.setRuleSetStoredInProject(true);
+        cmd.setRuleSetFile(ruleSetFileName);
+        cmd.execute();
+
+        // load the project settings - it should have this ruleset now active (1 rule)
+        final IProjectPropertiesManager mgr = PMDPlugin.getDefault().getPropertiesManager();
+        final IProjectProperties model = mgr.loadProjectProperties(this.testProject);
+        RuleSet projectRuleSet = model.getProjectRuleSet();
+        Assert.assertEquals(1, projectRuleSet.getRules().size());
+
+        // now let's change the ruleSetFile without eclipse knowing about it ("externally")
+        File ruleSetFileReal = ruleSetFile.getLocation().toFile();
+        try (FileOutputStream out = new FileOutputStream(ruleSetFileReal);
+             InputStream ruleset2 = ExternalRuleSetFileTest.class.getResourceAsStream("ruleset2.xml")) {
+            int count;
+            byte[] buffer = new byte[8192];
+            count = ruleset2.read(buffer);
+            while (count > -1) {
+                out.write(buffer, 0, count);
+                count = ruleset2.read(buffer);
+            }
+        }
+
+        // the file has changed, this should be detected
+        Assert.assertTrue(model.isNeedRebuild());
+        // the model is not updated yet...
+        Assert.assertEquals(1, model.getProjectRuleSet().getRules().size());
+        // but it will be when requesting the proejct properties again
+        final IProjectProperties model2 = mgr.loadProjectProperties(testProject);
+        Assert.assertEquals(2, model2.getProjectRuleSet().getRules().size());
+        // the model is still cached, but the rules are updated
+        Assert.assertSame(model, model2);
+    }
+}

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/ExternalRuleSetFileTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/ExternalRuleSetFileTest.java
@@ -5,8 +5,6 @@
 package net.sourceforge.pmd.eclipse.ui.properties;
 
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 
 import org.eclipse.core.resources.IFile;
@@ -21,6 +19,7 @@ import org.slf4j.LoggerFactory;
 import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.eclipse.EclipseUtils;
+import net.sourceforge.pmd.eclipse.internal.ResourceUtil;
 import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
 import net.sourceforge.pmd.eclipse.runtime.cmd.BuildProjectCommand;
 import net.sourceforge.pmd.eclipse.runtime.cmd.JobCommandProcessor;
@@ -94,7 +93,7 @@ public class ExternalRuleSetFileTest {
 
         // now let's change the ruleSetFile without eclipse knowing about it ("externally")
         File ruleSetFileReal = ruleSetFile.getLocation().toFile();
-        copyResource("ruleset2.xml", ruleSetFileReal);
+        ResourceUtil.copyResource(this, "ruleset2.xml", ruleSetFileReal);
 
         // the file has changed, this should be detected
         Assert.assertTrue(model.isNeedRebuild());
@@ -144,7 +143,7 @@ public class ExternalRuleSetFileTest {
             Assert.fail("File " + PROJECT_RULESET_FILENAME + " already exists!");
         }
         File ruleSetFileReal = ruleSetFile.getLocation().toFile();
-        copyResource("ruleset1.xml", ruleSetFileReal);
+        ResourceUtil.copyResource(this, "ruleset1.xml", ruleSetFileReal);
 
         // now overwrite and change the .pmd project properties without eclipse knowing about it ("externally")
         IFile projectPropertiesFile = this.testProject.getFile(".pmd");
@@ -152,7 +151,7 @@ public class ExternalRuleSetFileTest {
             Assert.fail("File .pmd does not exist!");
         }
         File projectPropertiesFileReal = projectPropertiesFile.getLocation().toFile();
-        copyResource("pmd-properties", projectPropertiesFileReal);
+        ResourceUtil.copyResource(this, "pmd-properties", projectPropertiesFileReal);
         LOG.debug("Overwritten {}", projectPropertiesFile);
 
         // the model is not updated yet...
@@ -174,18 +173,5 @@ public class ExternalRuleSetFileTest {
         JobCommandProcessor.getInstance().waitCommandToFinish(null);
         // need rebuild flag should be reset now
         Assert.assertFalse(model.isNeedRebuild());
-    }
-
-    private static void copyResource(String resource, File target) throws IOException {
-        try (FileOutputStream out = new FileOutputStream(target);
-                InputStream ruleset2 = ExternalRuleSetFileTest.class.getResourceAsStream(resource)) {
-            int count;
-            byte[] buffer = new byte[8192];
-            count = ruleset2.read(buffer);
-            while (count > -1) {
-                out.write(buffer, 0, count);
-                count = ruleset2.read(buffer);
-            }
-        }
     }
 }

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/UpdateProjectPropertiesCmdTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/UpdateProjectPropertiesCmdTest.java
@@ -12,7 +12,6 @@ import org.junit.Test;
 
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleSet;
-import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.eclipse.EclipseUtils;
 import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
 import net.sourceforge.pmd.eclipse.runtime.properties.IProjectProperties;
@@ -51,8 +50,6 @@ public class UpdateProjectPropertiesCmdTest {
      */
     @Test
     public void testBug() throws PropertiesException {
-        final RuleSetFactory factory = new RuleSetFactory();
-
         // First ensure that the plugin initial ruleset is equal to the project
         // ruleset
         final IProjectPropertiesManager mgr = PMDPlugin.getDefault().getPropertiesManager();

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/resources/net/sourceforge/pmd/eclipse/runtime/preferences/impl/pmd.prefs
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/resources/net/sourceforge/pmd/eclipse/runtime/preferences/impl/pmd.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+net.sourceforge.pmd.eclipse.plugin.active_rules=DoNotCallSystemExit

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/resources/net/sourceforge/pmd/eclipse/runtime/preferences/impl/test-ruleset.xml
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/resources/net/sourceforge/pmd/eclipse/runtime/preferences/impl/test-ruleset.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name="Custom Rules"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>
+        My custom rules
+    </description>
+
+
+    <rule ref="category/java/bestpractices.xml/AbstractClassWithoutAbstractMethod" />
+
+</ruleset>

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/resources/net/sourceforge/pmd/eclipse/ui/properties/pmd-properties
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/resources/net/sourceforge/pmd/eclipse/ui/properties/pmd-properties
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pmd>
+    <useProjectRuleSet>true</useProjectRuleSet>
+    <ruleSetFile>.pmd-ruleset.xml</ruleSetFile>
+    <includeDerivedFiles>false</includeDerivedFiles>
+    <violationsAsErrors>true</violationsAsErrors>
+    <fullBuildEnabled>true</fullBuildEnabled>
+</pmd>

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/resources/net/sourceforge/pmd/eclipse/ui/properties/ruleset1.xml
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/resources/net/sourceforge/pmd/eclipse/ui/properties/ruleset1.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<ruleset name="Custom Rules"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>
+        My custom rules
+    </description>
+
+
+    <rule ref="category/java/bestpractices.xml/AbstractClassWithoutAbstractMethod" />
+
+</ruleset>

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/resources/net/sourceforge/pmd/eclipse/ui/properties/ruleset2.xml
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/resources/net/sourceforge/pmd/eclipse/ui/properties/ruleset2.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset name="Custom Rules"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>
+        My custom rules
+    </description>
+
+
+    <rule ref="category/java/bestpractices.xml/AbstractClassWithoutAbstractMethod" />
+    <rule ref="category/java/bestpractices.xml/AccessorClassGeneration" />
+
+</ruleset>

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/core/internal/FileModificationUtil.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/core/internal/FileModificationUtil.java
@@ -2,7 +2,7 @@
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-package net.sourceforge.pmd.eclipse.runtime.properties.impl;
+package net.sourceforge.pmd.eclipse.core.internal;
 
 import java.io.File;
 import java.io.IOException;
@@ -12,14 +12,14 @@ import java.nio.file.attribute.FileTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class FileModificationUtil {
+public class FileModificationUtil {
     private static final Logger LOG = LoggerFactory.getLogger(FileModificationUtil.class);
 
     private FileModificationUtil() {
         // utility
     }
 
-    static long getFileModificationTimestamp(File f) {
+    public static long getFileModificationTimestamp(File f) {
         long result = 0L;
         if (f.exists()) {
             // Note: File::lastModified() might be not accurate enough, there's this bug:

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/logging/internal/LogbackConfiguration.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/logging/internal/LogbackConfiguration.java
@@ -110,6 +110,7 @@ public class LogbackConfiguration {
 
         Logger rootLogger = logbackContext.getLogger(ROOT_LOG_ID);
         rootLogger.addAppender(appender);
+        rootLogger.setLevel(Level.toLevel(logLevel, Level.INFO));
     }
 
     public void applyLogPreferences(String logFileName, String logLevel) {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/AbstractDefaultCommand.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/AbstractDefaultCommand.java
@@ -19,8 +19,6 @@ import net.sourceforge.pmd.lang.Language;
  */
 public abstract class AbstractDefaultCommand {
 
-    private static final long serialVersionUID = 1L;
-
     private boolean readOnly;
     private boolean outputProperties;
     private boolean readyToExecute;
@@ -213,7 +211,7 @@ public abstract class AbstractDefaultCommand {
      * @see org.eclipse.core.runtime.IProgressMonitor#isCanceled
      */
     protected boolean isCanceled() {
-        return monitor == null ? false : monitor.isCanceled();
+        return monitor != null && monitor.isCanceled();
     }
 
     /**

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BaseVisitor.java
@@ -273,8 +273,7 @@ public class BaseVisitor {
         if (PMDPlugin.getDefault().loadPreferences().isDetermineFiletypesAutomatically()) {
             if (fileExtensions != null) {
                 if (!fileExtensions.contains(file.getFileExtension().toLowerCase(Locale.ROOT))) {
-                    PMDPlugin.getDefault().logInformation("Skipping file " + file.getName() + " based on file extension");
-                    LOG.debug("Skipping file " + file.getName() + " based on file extension");
+                    LOG.debug("Skipping file {} based on file extension", file);
                     return;
                 }
             } else {
@@ -301,7 +300,7 @@ public class BaseVisitor {
             if (languageVersion != null) {
                 configuration().setDefaultLanguageVersion(languageVersion);
             }
-            LOG.debug("discovered language: " + languageVersion);
+            LOG.debug("discovered language: {}", languageVersion);
 
             if (PMDPlugin.getDefault().loadPreferences().isProjectBuildPathEnabled()) {
                 configuration().setClassLoader(projectProperties.getAuxClasspath());
@@ -335,7 +334,7 @@ public class BaseVisitor {
                 // but as we anyway have only one file to process, it won't hurt
                 // here.
                 configuration().setThreads(0);
-                LOG.debug("PMD running on file " + file.getName());
+                LOG.debug("PMD running on file {}", file.getName());
                 final Report collectingReport = new Report();
                 Renderer collectingRenderer = new AbstractRenderer("collectingRenderer",
                         "Renderer that collect violations") {
@@ -386,7 +385,7 @@ public class BaseVisitor {
 
                 pmdDuration += System.currentTimeMillis() - start;
 
-                LOG.debug("PMD found " + collectingReport.size() + " violations for file " + file.getName());
+                LOG.debug("PMD found {} violations for file {}", collectingReport.size(), file);
 
                 if (collectingReport.hasConfigErrors()) {
                     StringBuilder message = new StringBuilder("There were configuration errors!\n");
@@ -431,7 +430,7 @@ public class BaseVisitor {
             // TODO: complete message
             LOG.error("Properties exception visiting " + file.getName(), e);
         } catch (IllegalArgumentException e) {
-            LOG.error("Illegal argument", e);
+            LOG.error("Illegal argument: {}", e.toString(), e);
         } finally {
             IOUtil.closeQuietly(input);
         }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BuildProjectCommand.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/BuildProjectCommand.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -6,6 +6,8 @@ package net.sourceforge.pmd.eclipse.runtime.cmd;
 
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import net.sourceforge.pmd.eclipse.runtime.properties.PropertiesException;
 
@@ -16,12 +18,8 @@ import net.sourceforge.pmd.eclipse.runtime.properties.PropertiesException;
  *
  */
 public class BuildProjectCommand extends AbstractProjectCommand {
+    private static final Logger LOG = LoggerFactory.getLogger(BuildProjectCommand.class);
 
-    private static final long serialVersionUID = 1L;
-
-    /**
-     * @param NAME
-     */
     public BuildProjectCommand() {
         super("BuildProject", "Rebuild a project.");
 
@@ -34,6 +32,7 @@ public class BuildProjectCommand extends AbstractProjectCommand {
         try {
             project().build(IncrementalProjectBuilder.FULL_BUILD, this.getMonitor());
 
+            LOG.debug("Build for Project {} triggered, setting needRebuild=false", project().getName());
             projectProperties().setNeedRebuild(false);
         } catch (CoreException e) {
             throw new RuntimeException(e);

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/JobCommandProcessor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/JobCommandProcessor.java
@@ -21,8 +21,6 @@ import org.eclipse.core.runtime.jobs.Job;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
-
 /**
  * This is a particular processor for Eclipse in order to handle long running
  * commands.
@@ -45,7 +43,7 @@ public class JobCommandProcessor {
     }
 
     public void processCommand(final AbstractDefaultCommand aCommand) {
-        LOG.debug("Begining job command " + aCommand.getName());
+        LOG.debug("Beginning job command {}", aCommand.getName());
 
         if (!aCommand.isReadyToExecute()) {
             throw new IllegalStateException();
@@ -61,10 +59,9 @@ public class JobCommandProcessor {
                     long start = System.currentTimeMillis();
                     aCommand.execute();
                     long duration = System.currentTimeMillis() - start;
-                    PMDPlugin.getDefault().logInformation(
-                            "Command " + aCommand.getName() + " excecuted in " + duration + "ms");
+                    LOG.debug("Command {} executed in {} ms", aCommand.getName(), duration);
                 } catch (RuntimeException e) {
-                    PMDPlugin.getDefault().logError("Error executing command " + aCommand.getName(), e);
+                    LOG.error("Error executing command {}: {}", aCommand.getName(), e.toString(), e);
                 }
 
                 synchronized (outstanding) {
@@ -91,7 +88,7 @@ public class JobCommandProcessor {
             }
         }
         this.addJob(aCommand, job);
-        LOG.debug("Ending job command " + aCommand.getName());
+        LOG.debug("Ending job command {}", aCommand.getName());
     }
 
     public void waitCommandToFinish(final AbstractDefaultCommand aCommand) {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/ResourceVisitor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/cmd/ResourceVisitor.java
@@ -12,20 +12,17 @@ import org.slf4j.LoggerFactory;
 /**
  * This class visits all of the resources in the Eclipse Workspace, and runs PMD
  * on them if they happen to be Java files.
- * 
- * Any violations get tagged onto the file as problems in the tasks list.
- * 
+ *
+ * <p>Any violations get tagged onto the file as problems in the tasks list.
+ *
  * @author Philippe Herlin
  *
  */
 public class ResourceVisitor extends BaseVisitor implements IResourceVisitor {
     private static final Logger LOG = LoggerFactory.getLogger(ResourceVisitor.class);
 
-    /**
-     * @see org.eclipse.core.resources.IResourceVisitor#visit(IResource)
-     */
     public boolean visit(final IResource resource) {
-        LOG.debug("Visiting resource " + resource.getName());
+        LOG.debug("Visiting resource {}", resource.getName());
         boolean fVisitChildren = true;
 
         if (this.isCanceled()) {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/impl/PreferencesManagerImpl.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/impl/PreferencesManagerImpl.java
@@ -611,13 +611,10 @@ class PreferencesManagerImpl implements IPreferencesManager {
             try {
                 preferredRuleSet = factory.createRuleSet(ruleSetLocation.toOSString());
                 ruleSetModificationTimestamp = getRuleSetModificationTimestamp();
-            } catch (RuntimeException e) {
-                PMDPlugin.getDefault().showError(
-                        "Runtime Exception when loading stored ruleset file. Falling back to default ruleset.", e);
-            } catch (RuleSetNotFoundException e) {
-                PMDPlugin.getDefault().showError(
-                        "RuleSet Not Found Exception when loading stored ruleset file. Falling back to default ruleset.",
-                        e);
+            } catch (RuntimeException | RuleSetNotFoundException e) {
+                LOG.error("Error when loading stored ruleset file. Falling back to default ruleset: {}", e.toString(), e);
+                // also update the timestamp here to avoid running into the same error over and over again
+                ruleSetModificationTimestamp = getRuleSetModificationTimestamp();
             }
         }
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/FileModificationUtil.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/FileModificationUtil.java
@@ -1,0 +1,38 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.eclipse.runtime.properties.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.FileTime;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class FileModificationUtil {
+    private static final Logger LOG = LoggerFactory.getLogger(FileModificationUtil.class);
+
+    private FileModificationUtil() {
+        // utility
+    }
+
+    static long getFileModificationTimestamp(File f) {
+        long result = 0L;
+        if (f.exists()) {
+            // Note: File::lastModified() might be not accurate enough, there's this bug:
+            // https://bugs.openjdk.java.net/browse/JDK-8177809
+            FileTime filesLastMod;
+            try {
+                filesLastMod = Files.getLastModifiedTime(f.toPath());
+                result = filesLastMod.toMillis();
+                LOG.debug("File {} last mod: {}", f, result);
+            } catch (IOException e) {
+                LOG.debug("Error while reading file modification timestamp for {}: {}", f, e.toString());
+            }
+        }
+        return result;
+    }
+}

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesImpl.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesImpl.java
@@ -263,9 +263,7 @@ public class ProjectPropertiesImpl implements IProjectProperties {
      */
     @Override
     public boolean isNeedRebuild() {
-        LOG.debug("Query if project {} need rebuild : {}", project.getName(), pmdEnabled && needRebuild);
-        LOG.debug("   PMD Enabled = {}", pmdEnabled);
-        LOG.debug("   Project need rebuild =  {}", needRebuild);
+        LOG.debug("Query if project {} need rebuild : {}", project.getName(), needRebuild);
         if (ruleSetStoredInProject) {
             boolean rulesetFilesChanged = false;
             for (File f : getResolvedRuleSetFiles()) {
@@ -275,7 +273,7 @@ public class ProjectPropertiesImpl implements IProjectProperties {
             LOG.debug("   ruleset files have changed = {}", rulesetFilesChanged);
             this.setNeedRebuild(needRebuild | rulesetFilesChanged);
         }
-        return pmdEnabled && needRebuild;
+        return needRebuild;
     }
 
     /**

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesImpl.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesImpl.java
@@ -173,8 +173,9 @@ public class ProjectPropertiesImpl implements IProjectProperties {
         if (this.ruleSetStoredInProject) {
             for (File f : getResolvedRuleSetFiles()) {
                 if (f != null) {
-                    if (projectRuleFileLastModified < f.lastModified()) {
-                        projectRuleFileLastModified = f.lastModified();
+                    long mod = FileModificationUtil.getFileModificationTimestamp(f);
+                    if (projectRuleFileLastModified < mod) {
+                        projectRuleFileLastModified = mod;
                     }
                 }
             }
@@ -203,8 +204,9 @@ public class ProjectPropertiesImpl implements IProjectProperties {
             }
             for (File f : getResolvedRuleSetFiles()) {
                 if (f != null) {
-                    if (projectRuleFileLastModified < f.lastModified()) {
-                        projectRuleFileLastModified = f.lastModified();
+                    long mod = FileModificationUtil.getFileModificationTimestamp(f);
+                    if (projectRuleFileLastModified < mod) {
+                        projectRuleFileLastModified = mod;
                     }
                 }
             }
@@ -233,8 +235,9 @@ public class ProjectPropertiesImpl implements IProjectProperties {
             }
             for (File f : getResolvedRuleSetFiles()) {
                 if (f != null) {
-                    if (projectRuleFileLastModified < f.lastModified()) {
-                        projectRuleFileLastModified = f.lastModified();
+                    long mod = FileModificationUtil.getFileModificationTimestamp(f);
+                    if (projectRuleFileLastModified < mod) {
+                        projectRuleFileLastModified = mod;
                     }
                 }
             }
@@ -272,7 +275,8 @@ public class ProjectPropertiesImpl implements IProjectProperties {
             boolean rulesetFilesChanged = false;
             for (File f : getResolvedRuleSetFiles()) {
                 if (f != null) {
-                    rulesetFilesChanged |= f.lastModified() > projectRuleFileLastModified;
+                    long mod = FileModificationUtil.getFileModificationTimestamp(f);
+                    rulesetFilesChanged |= mod > projectRuleFileLastModified;
                 }
             }
             LOG.debug("   ruleset files have changed = {}", rulesetFilesChanged);
@@ -333,6 +337,9 @@ public class ProjectPropertiesImpl implements IProjectProperties {
                 if (f == null) {
                     // Fall back to file system path
                     f = new File(ruleSetFile);
+                    if (!f.canRead()) {
+                        f = null;
+                    }
                 }
             }
             files.add(f);

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesImpl.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesImpl.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RuleSets;
+import net.sourceforge.pmd.eclipse.core.internal.FileModificationUtil;
 import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
 import net.sourceforge.pmd.eclipse.runtime.cmd.JavaProjectClassLoader;
 import net.sourceforge.pmd.eclipse.runtime.properties.IProjectProperties;

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesImpl.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesImpl.java
@@ -173,11 +173,9 @@ public class ProjectPropertiesImpl implements IProjectProperties {
         this.projectRuleSets = newProjectRuleSets;
         if (this.ruleSetStoredInProject) {
             for (File f : getResolvedRuleSetFiles()) {
-                if (f != null) {
-                    long mod = FileModificationUtil.getFileModificationTimestamp(f);
-                    if (projectRuleFileLastModified < mod) {
-                        projectRuleFileLastModified = mod;
-                    }
+                long mod = FileModificationUtil.getFileModificationTimestamp(f);
+                if (projectRuleFileLastModified < mod) {
+                    projectRuleFileLastModified = mod;
                 }
             }
         }
@@ -204,11 +202,9 @@ public class ProjectPropertiesImpl implements IProjectProperties {
                         + " cannot be found for project " + this.project.getName());
             }
             for (File f : getResolvedRuleSetFiles()) {
-                if (f != null) {
-                    long mod = FileModificationUtil.getFileModificationTimestamp(f);
-                    if (projectRuleFileLastModified < mod) {
-                        projectRuleFileLastModified = mod;
-                    }
+                long mod = FileModificationUtil.getFileModificationTimestamp(f);
+                if (projectRuleFileLastModified < mod) {
+                    projectRuleFileLastModified = mod;
                 }
             }
         }
@@ -235,11 +231,9 @@ public class ProjectPropertiesImpl implements IProjectProperties {
                         "The project ruleset file cannot be found for project " + project.getName());
             }
             for (File f : getResolvedRuleSetFiles()) {
-                if (f != null) {
-                    long mod = FileModificationUtil.getFileModificationTimestamp(f);
-                    if (projectRuleFileLastModified < mod) {
-                        projectRuleFileLastModified = mod;
-                    }
+                long mod = FileModificationUtil.getFileModificationTimestamp(f);
+                if (projectRuleFileLastModified < mod) {
+                    projectRuleFileLastModified = mod;
                 }
             }
         }
@@ -275,10 +269,8 @@ public class ProjectPropertiesImpl implements IProjectProperties {
         if (ruleSetStoredInProject) {
             boolean rulesetFilesChanged = false;
             for (File f : getResolvedRuleSetFiles()) {
-                if (f != null) {
-                    long mod = FileModificationUtil.getFileModificationTimestamp(f);
-                    rulesetFilesChanged |= mod > projectRuleFileLastModified;
-                }
+                long mod = FileModificationUtil.getFileModificationTimestamp(f);
+                rulesetFilesChanged |= mod > projectRuleFileLastModified;
             }
             LOG.debug("   ruleset files have changed = {}", rulesetFilesChanged);
             this.setNeedRebuild(needRebuild | rulesetFilesChanged);
@@ -298,13 +290,16 @@ public class ProjectPropertiesImpl implements IProjectProperties {
      * @see net.sourceforge.pmd.eclipse.runtime.properties.IProjectProperties#isRuleSetFileExist()
      */
     public final boolean isRuleSetFileExist() {
-        boolean ret = true;
+        boolean allFilesCanBeRead = false;
         for (File f : getResolvedRuleSetFiles()) {
-            if (!f.exists()) {
-                ret = false;
+            if (f.canRead()) {
+                allFilesCanBeRead = true;
+            } else {
+                allFilesCanBeRead = false;
+                break;
             }
         }
-        return ret;
+        return allFilesCanBeRead;
     }
 
     @Deprecated
@@ -343,7 +338,9 @@ public class ProjectPropertiesImpl implements IProjectProperties {
                     }
                 }
             }
-            files.add(f);
+            if (f != null) {
+                files.add(f);
+            }
         }
         return files;
     }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesImpl.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesImpl.java
@@ -15,6 +15,7 @@ import java.util.Set;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IPath;
@@ -338,15 +339,18 @@ public class ProjectPropertiesImpl implements IProjectProperties {
     }
 
     private File getExistingFileOrNull(IFile file) {
+        // try to refresh the resource first - if the file has been created or deleted or modified externally
+        // eclipse might not know about it yet
+        try {
+            file.refreshLocal(IResource.DEPTH_ZERO, null);
+        } catch (CoreException e) {
+            LOG.warn("Error refreshing {}", file, e);
+        }
+
         boolean exists = file.exists() && file.isAccessible();
         File result = null;
         if (exists) {
-            File f = new File(file.getLocation().toOSString());
-            // For some reason IFile says exists when it doesn't! So double
-            // check.
-            if (f.exists()) {
-                result = f;
-            }
+            result = file.getLocation().toFile();
         }
         return result;
     }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesImpl.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesImpl.java
@@ -134,7 +134,7 @@ public class ProjectPropertiesImpl implements IProjectProperties {
      * @see net.sourceforge.pmd.eclipse.runtime.properties.IProjectProperties#setPmdEnabled(boolean)
      */
     public void setPmdEnabled(final boolean pmdEnabled) {
-        LOG.debug("Enable PMD for project {}: {}", this.project.getName(), this.pmdEnabled);
+        LOG.debug("Enable PMD for project {}: before={} now={}", this.project.getName(), this.pmdEnabled, pmdEnabled);
         if (this.pmdEnabled != pmdEnabled) {
             this.pmdEnabled = pmdEnabled;
             this.setNeedRebuild(this.needRebuild | pmdEnabled);
@@ -198,8 +198,8 @@ public class ProjectPropertiesImpl implements IProjectProperties {
         if (this.ruleSetStoredInProject) {
             if (!isRuleSetFileExist()) {
                 // TODO: NLS
-                throw new PropertiesException(
-                        "The project ruleset file cannot be found for project " + this.project.getName());
+                throw new PropertiesException("The project ruleset file(s) " + getRuleSetFile()
+                        + " cannot be found for project " + this.project.getName());
             }
             for (File f : getResolvedRuleSetFiles()) {
                 if (f != null) {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesManagerImpl.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesManagerImpl.java
@@ -92,7 +92,7 @@ public class ProjectPropertiesManagerImpl implements IProjectPropertiesManager {
                 }
             }
 
-            // if the ruleset is stored in the project always reload it
+            // if the ruleset is stored in the project reload it when it changed on disk (modification time stamp)
             if (projectProperties.isRuleSetStoredInProject()) {
                 loadRuleSetFromProject(projectProperties);
             } else {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesTimestampTupel.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesTimestampTupel.java
@@ -13,6 +13,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.sourceforge.pmd.eclipse.core.internal.FileModificationUtil;
 import net.sourceforge.pmd.eclipse.runtime.properties.IProjectProperties;
 
 class ProjectPropertiesTimestampTupel {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesTimestampTupel.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesTimestampTupel.java
@@ -1,0 +1,74 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.eclipse.runtime.properties.impl;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.attribute.FileTime;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import net.sourceforge.pmd.eclipse.runtime.properties.IProjectProperties;
+
+class ProjectPropertiesTimestampTupel {
+    private static final Logger LOG = LoggerFactory.getLogger(ProjectPropertiesTimestampTupel.class);
+
+    static final String PROPERTIES_FILE = ".pmd";
+
+    private final IProjectProperties projectProperties;
+    private long lastReadTimestamp;
+
+    ProjectPropertiesTimestampTupel(IProjectProperties projectProperties) {
+        super();
+        this.projectProperties = projectProperties;
+        this.lastReadTimestamp = getModificationTimestamp();
+    }
+
+    IProjectProperties getProjectProperties() {
+        return projectProperties;
+    }
+
+    IProject getProject() {
+        return projectProperties.getProject();
+    }
+
+    boolean isOutOfSync() throws CoreException {
+        IProject project = projectProperties.getProject();
+        IFile propertiesFile = project.getFile(PROPERTIES_FILE);
+        if (!propertiesFile.isSynchronized(IResource.DEPTH_ZERO)) {
+            LOG.debug("File {} is out of sync... refreshing initiated", propertiesFile);
+            // refresh the file, so that a later load content works
+            propertiesFile.refreshLocal(IResource.DEPTH_ZERO, null);
+        }
+
+        long newTimestamp = getModificationTimestamp();
+        LOG.debug("Comparing timestamps for {}: lastRead={}, new={}", propertiesFile, lastReadTimestamp, newTimestamp);
+        if (newTimestamp != lastReadTimestamp) {
+            lastReadTimestamp = newTimestamp;
+            return true;
+        }
+        return false;
+    }
+
+    private long getModificationTimestamp() {
+        IProject project = projectProperties.getProject();
+        IFile propertiesFile = project.getFile(PROPERTIES_FILE);
+
+        long result = 0L;
+        try {
+            FileTime filesLastMod = Files.getLastModifiedTime(propertiesFile.getLocation().toFile().toPath());
+            result = filesLastMod.toMillis();
+            LOG.debug("File {} last mod: {}", propertiesFile, result);
+        } catch (IOException e) {
+            LOG.debug("Error while reading file modification time", e);
+        }
+        return result;
+    }
+}

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesTimestampTupel.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesTimestampTupel.java
@@ -5,9 +5,6 @@
 package net.sourceforge.pmd.eclipse.runtime.properties.impl;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.attribute.FileTime;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IProject;
@@ -62,19 +59,7 @@ class ProjectPropertiesTimestampTupel {
         IProject project = projectProperties.getProject();
         IFile propertiesFile = project.getFile(PROPERTIES_FILE);
 
-        long result = 0L;
-        try {
-            File propertiesFileReal = propertiesFile.getLocation().toFile();
-            if (propertiesFileReal.exists()) {
-                // Note: File::lastModified() might be not accurate enough, there's this bug:
-                // https://bugs.openjdk.java.net/browse/JDK-8177809
-                FileTime filesLastMod = Files.getLastModifiedTime(propertiesFileReal.toPath());
-                result = filesLastMod.toMillis();
-                LOG.debug("File {} last mod: {}", propertiesFile, result);
-            }
-        } catch (IOException e) {
-            LOG.debug("Error while reading file modification time: {}", e.toString());
-        }
-        return result;
+        File propertiesFileReal = propertiesFile.getLocation().toFile();
+        return FileModificationUtil.getFileModificationTimestamp(propertiesFileReal);
     }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesTimestampTupel.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesTimestampTupel.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.eclipse.runtime.properties.impl;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.attribute.FileTime;
@@ -63,11 +64,16 @@ class ProjectPropertiesTimestampTupel {
 
         long result = 0L;
         try {
-            FileTime filesLastMod = Files.getLastModifiedTime(propertiesFile.getLocation().toFile().toPath());
-            result = filesLastMod.toMillis();
-            LOG.debug("File {} last mod: {}", propertiesFile, result);
+            File propertiesFileReal = propertiesFile.getLocation().toFile();
+            if (propertiesFileReal.exists()) {
+                // Note: File::lastModified() might be not accurate enough, there's this bug:
+                // https://bugs.openjdk.java.net/browse/JDK-8177809
+                FileTime filesLastMod = Files.getLastModifiedTime(propertiesFileReal.toPath());
+                result = filesLastMod.toMillis();
+                LOG.debug("File {} last mod: {}", propertiesFile, result);
+            }
         } catch (IOException e) {
-            LOG.debug("Error while reading file modification time", e);
+            LOG.debug("Error while reading file modification time: {}", e.toString());
         }
         return result;
     }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/UpdateProjectPropertiesCmd.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/UpdateProjectPropertiesCmd.java
@@ -51,8 +51,9 @@ public class UpdateProjectPropertiesCmd extends AbstractProjectCommand {
             properties.setPmdEnabled(pmdEnabled);
             properties.setProjectRuleSets(projectRuleSets);
             properties.setProjectWorkingSet(projectWorkingSet);
-            properties.setRuleSetStoredInProject(ruleSetStoredInProject);
+            // ruleSetFile has to be set before ruleSetStoredInProject!
             properties.setRuleSetFile(ruleSetFile);
+            properties.setRuleSetStoredInProject(ruleSetStoredInProject);
             properties.setIncludeDerivedFiles(includeDerivedFiles);
             properties.setFullBuildEnabled(fullBuildEnabled);
             properties.setViolationsAsErrors(violationsAsErrors);


### PR DESCRIPTION
## Goals

* When the project properties file `.pmd` is changed by an external process (or another Java VM) while eclipse is running, the file should be reread to apply any changes.
* When the project ruleset is stored within the project (option "Use ruleset configured in a project file") and this ruleset is changed by an external process (or another Java VM) while eclipse is running, the file should be reread to apply any changes.
* When PMD's preferences file is changed by an external process (or another Java VM) while eclipse is running, the preferences should be reread to apply any changes.
* When PMD's ruleset file (configurable on preferences page "Rule Configuration") is changed by an external process (or another Java VM) while eclipse is running, the ruleset should be reread to apply any changes.

## Solution and Background info
PMD (and eclipse) caches these files while eclipse is running. But the cache is never invalidated.
In order to detect such external changes, the modification timestamp of the files is used. If the modification timestamp changed since the file was last time read, the file is re-read from disk.

The modification timestamp solution was already implemented for the project rulesets, but was missing for the 3 other cases.

When re-reading the changes, any changes done in the running eclipse instance might be lost. In order to minimize this case of preferences, the preferences are now flushed as soon as the Preferences Dialog is closed with "Apply & Close". This of course overwrites any changes done on disk while the dialog is open.
It should be obvious, that changing the preferences via the dialog and via an external process is to be avoided as the result is undefined.

The following cases are considered:
* [x] If a project is configured to use a ruleset stored as a file in the project, and this ruleset is changed externally, then it should be refreshed.
* [x] If a project has PMD already configured. Now the `.pmd` file is changed so that the project should use a ruleset stored in the project file, then the plugin should pick up this change.
* [x] The plugin stores the "global ruleset" (aka the "default plugin ruleset") in the workspace. If this ruleset file is changed, it should be reloaded.
* [x] The plugin stores preferences with the standard preferences impl of eclipse. If the preferences file is changed externally, the plugin should reload the preferences ("sync") rather than overwrite the changes on disk with the cached values ("flush").
* [x] When PMD is not enabled for a project (nature/builders are not added), then the ruleset (if stored in an external file) should still be reloaded, if it is changed externally. This is needed, because you can execute PMD manually for a project, even if PMD is not enabled.
