### PR TITLE
Remove log4j

### DIFF
--- a/kepler/kepler.target
+++ b/kepler/kepler.target
@@ -21,8 +21,6 @@
             <unit id="ch.qos.logback.slf4j.source" version="1.0.7.v20121108-1250"/>
             <unit id="org.slf4j.jul" version="1.7.2.v20121108-1250"/>
             <unit id="org.slf4j.jul.source" version="1.7.2.v20121108-1250"/>
-            <unit id="org.slf4j.log4j" version="1.7.2.v20130115-1340"/>
-            <unit id="org.slf4j.log4j.source" version="1.7.2.v20130115-1340"/>
         </location>
     </locations>
     <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>

--- a/net.sourceforge.pmd.eclipse.p2updatesite/category.xml
+++ b/net.sourceforge.pmd.eclipse.p2updatesite/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature id="net.sourceforge.pmd.eclipse" version="4.18.0.qualifier">
+   <feature id="net.sourceforge.pmd.eclipse" version="${unqualifiedVersion}.qualifier">
       <category name="pmdForEclipse"/>
    </feature>
    <category-def name="pmdForEclipse" label="PMD for Eclipse">

--- a/net.sourceforge.pmd.eclipse.p2updatesite/category.xml
+++ b/net.sourceforge.pmd.eclipse.p2updatesite/category.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature id="net.sourceforge.pmd.eclipse" version="${unqualifiedVersion}.qualifier">
+   <feature id="net.sourceforge.pmd.eclipse" version="4.18.0.qualifier">
       <category name="pmdForEclipse"/>
    </feature>
    <category-def name="pmdForEclipse" label="PMD for Eclipse">

--- a/net.sourceforge.pmd.eclipse.plugin/META-INF/MANIFEST.MF
+++ b/net.sourceforge.pmd.eclipse.plugin/META-INF/MANIFEST.MF
@@ -113,7 +113,6 @@ Export-Package: name.herlin.command,
  net.sourceforge.pmd.eclipse.runtime;uses:="net.sourceforge.pmd.lang.rule.properties",
  net.sourceforge.pmd.eclipse.runtime.builder;
   uses:="org.eclipse.core.runtime,
-   org.apache.log4j,
    org.eclipse.core.resources,
    net.sourceforge.pmd.eclipse.ui.model",
  net.sourceforge.pmd.eclipse.runtime.cmd,
@@ -171,5 +170,4 @@ Export-Package: name.herlin.command,
  net.sourceforge.pmd.renderers,
  net.sourceforge.pmd.util;uses:="net.sourceforge.pmd.lang.java.ast",
  net.sourceforge.pmd.util.datasource
-Import-Package: org.apache.log4j,
- org.slf4j
+Import-Package: org.slf4j

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/IPreferences.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/IPreferences.java
@@ -6,8 +6,6 @@ package net.sourceforge.pmd.eclipse.runtime.preferences;
 
 import java.util.Set;
 
-import org.apache.log4j.Level;
-
 import net.sourceforge.pmd.RulePriority;
 import net.sourceforge.pmd.eclipse.ui.priority.PriorityDescriptor;
 
@@ -34,8 +32,6 @@ public interface IPreferences {
     boolean REVIEW_PMD_STYLE_ENABLED_DEFAULT = true;
     int MIN_TILE_SIZE_DEFAULT = 25;
     String LOG_FILENAME_DEFAULT = System.getProperty("user.home") + "/pmd-eclipse.log";
-    @Deprecated // use LOG_LEVEL_DEFAULT instead
-    Level LOG_LEVEL = Level.WARN;
     String LOG_LEVEL_DEFAULT = "WARN";
 
     // default renderer
@@ -214,21 +210,7 @@ public interface IPreferences {
      */
     void setLogFileName(String logFileName);
 
-    /**
-     * Return the log level
-     * @deprecated use {@link #getLogLevelName()}
-     */
-    @Deprecated
-    Level getLogLevel();
-
     String getLogLevelName();
-
-    /**
-     * Set the log level
-     * @deprecated use {@link #setLogLevel(String)}
-     */
-    @Deprecated
-    void setLogLevel(Level level);
 
     void setLogLevel(String level);
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/impl/PreferencesImpl.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/preferences/impl/PreferencesImpl.java
@@ -9,8 +9,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.log4j.Level;
-
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RulePriority;
 import net.sourceforge.pmd.RuleSet;
@@ -206,15 +204,6 @@ class PreferencesImpl implements IPreferences {
         return logFileName;
     }
 
-    /**
-     * @see net.sourceforge.pmd.eclipse.runtime.preferences.IPreferences#getLogLevel()
-     */
-    @Deprecated
-    @Override
-    public Level getLogLevel() {
-        return Level.toLevel(logLevel);
-    }
-
     @Override
     public String getLogLevelName() {
         return logLevel;
@@ -225,15 +214,6 @@ class PreferencesImpl implements IPreferences {
      */
     public void setLogFileName(String logFileName) {
         this.logFileName = logFileName;
-    }
-
-    /**
-     * @see net.sourceforge.pmd.eclipse.runtime.preferences.IPreferences#setLogLevel(org.apache.log4j.Level)
-     */
-    @Deprecated
-    @Override
-    public void setLogLevel(Level level) {
-        logLevel = level.toString();
     }
 
     @Override

--- a/net.sourceforge.pmd.eclipse/feature.xml
+++ b/net.sourceforge.pmd.eclipse/feature.xml
@@ -38,20 +38,4 @@
          install-size="0"
          version="4.18.0.qualifier"/>
 
-   <!--
-     org.slf4j.log4j is included for convenience, so that it doesn't need to be fetched from orbit.
-     Adding it here will add it to the update site of pmd-eclipse-plugin.
-     
-     In newer eclipse installations, slf4j and logback itself is already installed, only this old log4j
-     dependency is needed.
-     
-     Note: log4j is only needed to provide compatibility, see https://github.com/pmd/pmd-eclipse-plugin/pull/112
-   -->
-   <plugin
-         id="org.slf4j.log4j"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>


### PR DESCRIPTION
Removes all references to Log4j to fix #131. With this change, my Eclipse installation is happy again.

I think this could technically break other plugins if they depend on the PMD plugin and happen to use the removed methods. But I doubt there are any such plugins. I searched the Eclipse Marketplace and the only plugin that looks like it depends on the PMD plugin is m2e-code-quality, and that does not refer to the removed methods.