### PR TITLE
Refactor actions to use correct selection

### DIFF
--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/actions/AbstractUIAction.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/actions/AbstractUIAction.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.eclipse.ui.views.ViolationOverview;
  */
 public abstract class AbstractUIAction implements IObjectActionDelegate {
 
+    private ISelection selection;
     private IWorkbenchPart targetPart;
 
     protected AbstractUIAction() {
@@ -59,7 +60,12 @@ public abstract class AbstractUIAction implements IObjectActionDelegate {
     }
 
     protected ISelection targetSelection() {
-        return targetPartSite().getSelectionProvider().getSelection();
+        return selection;
+    }
+
+    @Override
+    public void selectionChanged(IAction action, ISelection selection) {
+        this.selection = selection;
     }
 
     /**

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/actions/CPDCheckProjectAction.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/actions/CPDCheckProjectAction.java
@@ -47,12 +47,10 @@ public class CPDCheckProjectAction extends AbstractUIAction {
     private static final String SIMPLE_KEY = "Simple Text";
     private static final String CSV_KEY = "CSV";
 
-    /*
-     * @see org.eclipse.ui.IActionDelegate#run(IAction)
-     */
+    @Override
     public void run(final IAction action) { // NOPMD:UnusedFormalParameter
         final IWorkbenchPartSite site = targetPartSite();
-        final ISelection sel = site.getSelectionProvider().getSelection();
+        final ISelection sel = targetSelection();
         final Shell shell = site.getShell();
         final String[] languages = LanguageFactory.supportedLanguages;
         
@@ -64,7 +62,7 @@ public class CPDCheckProjectAction extends AbstractUIAction {
         
         final CPDCheckDialog dialog = new CPDCheckDialog(shell, languages, formats);
         
-        if (dialog.open() == Dialog.OK && sel instanceof IStructuredSelection) {       
+        if (dialog.open() == Dialog.OK && sel instanceof IStructuredSelection) {
             final StructuredSelection ss = (StructuredSelection) sel;
             final Iterator<?> i = ss.iterator();
             while (i.hasNext()) {
@@ -83,15 +81,8 @@ public class CPDCheckProjectAction extends AbstractUIAction {
                     LOG.warn("The selected object is not adaptable");
                     LOG.debug("   -> selected object : " + obj);
                 }
-            }           
+            }
         }
-    }
-
-
-    /*
-     * @see org.eclipse.ui.IActionDelegate#selectionChanged(IAction, ISelection)
-     */
-    public void selectionChanged(final IAction action, final ISelection selection) { // NOPMD:UnusedFormalParameter
     }
 
     /**
@@ -173,5 +164,4 @@ public class CPDCheckProjectAction extends AbstractUIAction {
         }
         return fileName;
     }
-    
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/actions/GenerateReportAction.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/actions/GenerateReportAction.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.eclipse.ui.actions;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.IAdaptable;
@@ -20,7 +21,6 @@ import net.sourceforge.pmd.eclipse.runtime.cmd.RenderReportsCmd;
 import net.sourceforge.pmd.eclipse.ui.nls.StringKeys;
 import net.sourceforge.pmd.eclipse.ui.reports.ReportManager;
 import net.sourceforge.pmd.renderers.Renderer;
-import net.sourceforge.pmd.util.StringUtil;
 
 /**
  * Process GenerateReport action menu. Generate a HTML report on the current
@@ -57,7 +57,7 @@ public class GenerateReportAction extends AbstractUIAction {
 
         for (Renderer renderer : renderers) {
             String issue = renderer.dysfunctionReason();
-            if (StringUtil.isNotEmpty(issue)) {
+            if (StringUtils.isNotBlank(issue)) {
                 errors.append(renderer.getName()).append(": ");
                 errors.append(issue).append("\n");
             }
@@ -71,9 +71,7 @@ public class GenerateReportAction extends AbstractUIAction {
         return false;
     }
 
-    /**
-     * @see org.eclipse.ui.IActionDelegate#run(IAction)
-     */
+    @Override
     public final void run(final IAction action) {
         LOG.info("Generation Report action requested");
         final ISelection sel = targetSelection();
@@ -99,22 +97,14 @@ public class GenerateReportAction extends AbstractUIAction {
     }
 
     /**
-     * @see org.eclipse.ui.IActionDelegate#selectionChanged(IAction, ISelection)
-     */
-    public final void selectionChanged(IAction action, ISelection selection) {
-        // nothing to do
-    }
-
-    /**
      * Get a project from a selection
      * 
      * @param selection
      * @return
      */
     private static IProject getProject(IStructuredSelection selection) {
-
         Object object = selection.getFirstElement();
-        if (object != null && object instanceof IAdaptable) {
+        if (object instanceof IAdaptable) {
             final IResource resource = (IResource) ((IAdaptable) object).getAdapter(IResource.class);
             if (resource != null) {
                 return resource.getProject();

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/actions/PMDCheckAction.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/actions/PMDCheckAction.java
@@ -11,9 +11,6 @@ import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.ui.IEditorInput;
-import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IWorkingSet;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,62 +31,28 @@ public class PMDCheckAction extends AbstractUIAction {
     private static final Logger LOG = LoggerFactory.getLogger(PMDCheckAction.class);
 
     /**
-     * @see org.eclipse.ui.IActionDelegate#run(IAction)
+     * 
      */
+    public PMDCheckAction() {
+        LOG.info("New Check Action created...");
+    }
+    
+    @Override
     public void run(IAction action) {
         LOG.info("Check PMD action requested");
 
         try {
-
-            // Execute PMD on a range of selected resource if action selected
-            // from a view part
-            if (isViewPart()) {
-                ISelection selection = targetSelection();
-                if (selection instanceof IStructuredSelection) {
-                    reviewSelectedResources((IStructuredSelection) selection);
-                } else {
-                    LOG.debug("The selection is not an instance of IStructuredSelection. This is not supported: "
-                            + selection.getClass().getName());
-                }
-            } else if (isEditorPart()) {
-                // If action is selected from an editor, run PMD on the file
-                // currently edited
-                IEditorInput editorInput = ((IEditorPart) targetPart()).getEditorInput();
-                if (editorInput instanceof IFileEditorInput) {
-                    reviewSingleResource(((IFileEditorInput) editorInput).getFile());
-                } else {
-                    LOG.debug("The kind of editor input is not supported. The editor input if of type: "
-                            + editorInput.getClass().getName());
-                }
+            ISelection selection = targetSelection();
+            if (selection instanceof IStructuredSelection) {
+                reviewSelectedResources((IStructuredSelection) selection);
             } else {
-                // Else, this is not supported for now
-                LOG.debug("Running PMD from this kind of part is not supported. Part is of type "
-                        + targetPartClassName());
+                LOG.debug("The selection is not an instance of IStructuredSelection. This is not supported: "
+                        + selection.getClass().getName());
             }
-
         } catch (RuntimeException e) {
             showErrorById(StringKeys.ERROR_CORE_EXCEPTION, e);
         }
 
-    }
-
-    /**
-     * @see org.eclipse.ui.IActionDelegate#selectionChanged(IAction, ISelection)
-     */
-    @Override
-    public void selectionChanged(IAction action, ISelection selection) {
-    }
-
-    /**
-     * Run the reviewCode command on a single resource
-     *
-     * @param resource
-     */
-    private void reviewSingleResource(IResource resource) {
-        ReviewCodeCmd cmd = new ReviewCodeCmd();
-        cmd.addResource(resource);
-
-        setupAndExecute(cmd);
     }
 
     private void setupAndExecute(ReviewCodeCmd cmd) {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/actions/PMDRemoveMarkersAction.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/actions/PMDRemoveMarkersAction.java
@@ -14,9 +14,6 @@ import org.eclipse.core.runtime.IAdaptable;
 import org.eclipse.jface.action.IAction;
 import org.eclipse.jface.viewers.ISelection;
 import org.eclipse.jface.viewers.IStructuredSelection;
-import org.eclipse.ui.IEditorInput;
-import org.eclipse.ui.IEditorPart;
-import org.eclipse.ui.IFileEditorInput;
 import org.eclipse.ui.IViewActionDelegate;
 import org.eclipse.ui.IViewPart;
 import org.slf4j.Logger;
@@ -39,16 +36,12 @@ public class PMDRemoveMarkersAction extends AbstractUIAction implements IViewAct
     private static final String OBJECT_ACTION = "net.sourceforge.pmd.eclipse.ui.pmdRemoveMarkersAction";
     private static final Logger LOG = LoggerFactory.getLogger(PMDRemoveMarkersAction.class);
 
-    /**
-     * @see org.eclipse.ui.IViewActionDelegate#init(IViewPart)
-     */
+    @Override
     public void init(IViewPart view) {
-        // no initialization for now
+        setActivePart(null, view);
     }
 
-    /**
-     * @see org.eclipse.ui.IActionDelegate#run(IAction)
-     */
+    @Override
     public void run(IAction action) {
         LOG.info("Remove Markers action requested");
         try {
@@ -67,46 +60,22 @@ public class PMDRemoveMarkersAction extends AbstractUIAction implements IViewAct
     }
 
     /**
-     * @see org.eclipse.ui.IActionDelegate#selectionChanged(IAction, ISelection)
-     */
-    public void selectionChanged(IAction action, ISelection selection) {
-        // nothing to do
-    }
-
-    /**
      * Process removing of makers on a resource selection (project or file)
      */
     private void processResource() {
         LOG.debug("Processing a resource");
         try {
-            if (isViewPart()) {
-                // if action is run from a view, process the selected resources
-                final ISelection sel = targetSelection();
+            // if action is run from a view, process the selected resources
+            final ISelection sel = targetSelection();
 
-                if (sel instanceof IStructuredSelection) {
-                    final IStructuredSelection structuredSel = (IStructuredSelection) sel;
-                    for (final Iterator<?> i = structuredSel.iterator(); i.hasNext();) {
-                        final Object element = i.next();
-                        processElement(element);
-                    }
-                } else {
-                    LOG.warn("The view part selection is not a structured selection !");
-                }
-            } else if (isEditorPart()) {
-                // if action is run from an editor, process the file currently
-                // edited
-                final IEditorInput editorInput = ((IEditorPart) targetPart()).getEditorInput();
-                if (editorInput instanceof IFileEditorInput) {
-                    MarkerUtil.deleteAllMarkersIn(((IFileEditorInput) editorInput).getFile());
-                    LOG.debug("Remove markers on currently edited file "
-                            + ((IFileEditorInput) editorInput).getFile().getName());
-                } else {
-                    LOG.debug("The kind of editor input is not supported. The editor input type: "
-                            + editorInput.getClass().getName());
+            if (sel instanceof IStructuredSelection) {
+                final IStructuredSelection structuredSel = (IStructuredSelection) sel;
+                for (final Iterator<?> i = structuredSel.iterator(); i.hasNext();) {
+                    final Object element = i.next();
+                    processElement(element);
                 }
             } else {
-                // else, this is not supported
-                LOG.debug("This action is not supported on that part. This part type is: " + targetPartClassName());
+                LOG.warn("The view part selection is not a structured selection !");
             }
         } catch (CoreException e) {
             showErrorById(StringKeys.ERROR_CORE_EXCEPTION, e);


### PR DESCRIPTION
Previously selectionChanged was ignored and the selected elements
where determined manually by getting the selection from the ui part
the action is used for. However, this makes it impossible to
programmatically call this action and provide a specific selection.

This drastically simplifies the actions, since they mostly care about
the selection and the selection is provided by eclipse automatically.

Also fixes PMD issues and invalid charset handling while removing
review comments.