### PR TITLE
Execute org.eclipse.swt.graphics.GC call in UI thread in ShapePainter

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -15,6 +15,7 @@ This is a minor release.
 
 ### Fixed Issues
 
+*   [#148](https://github.com/pmd/pmd-eclipse-plugin/issues/148): Eclipse nearly-consistently crashes on startup when workspace contains PMD enabled projects
 *   [#150](https://github.com/pmd/pmd-eclipse-plugin/issues/150): Error executing command ReviewCode: java.util.regex.PatternSyntaxException: Illegal/unsupported escape sequence near index
 *   [#153](https://github.com/pmd/pmd-eclipse-plugin/issues/153): Not properly disposed SWT resource
 
@@ -28,6 +29,7 @@ This is a minor release.
 *   `net.sourceforge.pmd.eclipse.runtime.cmd.BaseVisitor.setUseTaskMarker(boolean)`
 *   `net.sourceforge.pmd.eclipse.ui.preferences.br.FilterManager`
 *   `net.sourceforge.pmd.eclipse.util.IOUtil`
+*   `net.sourceforge.pmd.eclipse.ui.priority.PriorityDescriptor.refreshImages()`
 *   All classes that couldn't be instantiated because they had a private constructor only
     are now also `final`.
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/PMDPlugin.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/PMDPlugin.java
@@ -334,7 +334,7 @@ public class PMDPlugin extends AbstractUIPlugin {
      * @param viewId id of the view 
      */ 
     public void refreshView(final String viewId) {
-        Display.getCurrent().asyncExec(new Runnable() {
+        Display.getDefault().asyncExec(new Runnable() {
             @Override
             public void run() {
                 try {
@@ -447,7 +447,7 @@ public class PMDPlugin extends AbstractUIPlugin {
             @Override
             public void run() {
                 String errTitle = getStringTable().getString(StringKeys.ERROR_TITLE);
-                MessageDialog.openError(Display.getCurrent().getActiveShell(), errTitle,
+                MessageDialog.openError(Display.getDefault().getActiveShell(), errTitle,
                         message + "\n" + String.valueOf(t));
             }
         });
@@ -462,7 +462,7 @@ public class PMDPlugin extends AbstractUIPlugin {
             @Override
             public void run() {
                 String errTitle = getStringTable().getString(StringKeys.ERROR_TITLE);
-                MessageDialog.openError(Display.getCurrent().getActiveShell(), errTitle, message);
+                MessageDialog.openError(Display.getDefault().getActiveShell(), errTitle, message);
             }
         });
     }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/PageBuilder.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/PageBuilder.java
@@ -37,7 +37,7 @@ import net.sourceforge.pmd.lang.Language;
  */
 public class PageBuilder {
     private static final char CR = '\n';
-    private static final Color BACKGROUND = Display.getCurrent().getSystemColor(SWT.COLOR_WHITE);
+    private static final Color BACKGROUND = Display.getDefault().getSystemColor(SWT.COLOR_WHITE);
     
     private static final Comparator<StyleRange> STYLE_COMPARATOR = new Comparator<StyleRange>() {
         @Override
@@ -62,7 +62,7 @@ public class PageBuilder {
         buffer = new StringBuilder(500);
         indentDepth = textIndent;
 
-        Display display = Display.getCurrent();
+        Display display = Display.getDefault();
         headingColor = display.getSystemColor(headingColorIndex);
         codeStyle = codeFontBuilder.style(display);
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/ShapePicker.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/ShapePicker.java
@@ -118,7 +118,7 @@ public class ShapePicker<T extends Object> extends Canvas implements ISelectionP
     private Color colourFor(int itemIndex) {
         ShapeDescriptor desc = shapeDescriptorsByItem.get(items[itemIndex]);
         if (desc == null) {
-            return Display.getCurrent().getSystemColor(SWT.COLOR_BLACK);
+            return Display.getDefault().getSystemColor(SWT.COLOR_BLACK);
         }
 
         RGB rgb = desc.rgbColor;

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/actions/ClearReviewsAction.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/actions/ClearReviewsAction.java
@@ -57,7 +57,7 @@ public class ClearReviewsAction extends AbstractUIAction implements IResourceVis
     @Override
     public void run(IAction action) {
         LOG.info("Remove violation reviews requested.");
-        ProgressMonitorDialog monitorDialog = new ProgressMonitorDialog(Display.getCurrent().getActiveShell());
+        ProgressMonitorDialog monitorDialog = new ProgressMonitorDialog(Display.getDefault().getActiveShell());
         try {
             monitorDialog.run(false, false, new IRunnableWithProgress() {
                 @Override

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/editors/StyleExtractor.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/editors/StyleExtractor.java
@@ -24,12 +24,12 @@ public class StyleExtractor {
     private SyntaxData syntaxData;
     private List<int[]> commentOffsets;
 
-    private static final Color COMMENT_COLOR = Display.getCurrent().getSystemColor(SWT.COLOR_DARK_GREEN);
-    private static final Color REFERENCED_VAR_COLOR = Display.getCurrent().getSystemColor(SWT.COLOR_DARK_GREEN);
-    private static final Color COMMENT_BACKGROUND = Display.getCurrent().getSystemColor(SWT.COLOR_WHITE);
-    private static final Color PUNCTUATION_COLOR = Display.getCurrent().getSystemColor(SWT.COLOR_BLACK);
-    private static final Color KEYWORD_COLOR = Display.getCurrent().getSystemColor(SWT.COLOR_DARK_MAGENTA);
-    private static final Color STRING_COLOR = Display.getCurrent().getSystemColor(SWT.COLOR_BLUE);
+    private static final Color COMMENT_COLOR = Display.getDefault().getSystemColor(SWT.COLOR_DARK_GREEN);
+    private static final Color REFERENCED_VAR_COLOR = Display.getDefault().getSystemColor(SWT.COLOR_DARK_GREEN);
+    private static final Color COMMENT_BACKGROUND = Display.getDefault().getSystemColor(SWT.COLOR_WHITE);
+    private static final Color PUNCTUATION_COLOR = Display.getDefault().getSystemColor(SWT.COLOR_BLACK);
+    private static final Color KEYWORD_COLOR = Display.getDefault().getSystemColor(SWT.COLOR_DARK_MAGENTA);
+    private static final Color STRING_COLOR = Display.getDefault().getSystemColor(SWT.COLOR_BLUE);
 
     public StyleExtractor(SyntaxData theSyntaxData) {
         syntaxData = theSyntaxData;

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/AbstractTreeTableManager.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/br/AbstractTreeTableManager.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.eclipse.jface.viewers.CheckboxTreeViewer;
 import org.eclipse.jface.viewers.ISelectionChangedListener;
@@ -129,16 +130,21 @@ public abstract class AbstractTreeTableManager<T extends Object> extends Abstrac
     }
 
     protected void createCheckBoxColumn(Tree tree) {
-
         TreeColumn tc = new TreeColumn(tree, 0);
 
-        Image image = new Image(Display.getCurrent(), 15, 15);
-        GC gc = new GC(image);
-        Point textExtent = gc.textExtent("m");
-        gc.dispose();
-        image.dispose();
+        final AtomicReference<Point> textExtent = new AtomicReference<>();
+        Display.getDefault().syncExec(new Runnable() {
+            @Override
+            public void run() {
+                Image image = new Image(Display.getDefault(), 15, 15);
+                GC gc = new GC(image);
+                textExtent.set(gc.textExtent("m"));
+                gc.dispose();
+                image.dispose();
+            }
+        });
 
-        tc.setWidth(textExtent.x * 4);
+        tc.setWidth(textExtent.get().x * 4);
 
         tc.setResizable(true);
         tc.pack();

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/AbstractEditorFactory.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/preferences/editors/AbstractEditorFactory.java
@@ -32,7 +32,7 @@ public abstract class AbstractEditorFactory<T> implements EditorFactory<T> {
     // private static ColourManager colourManager() {
     //
     // if (colourManager != null) return colourManager;
-    // colourManager = ColourManager.managerFor(Display.getCurrent());
+    // colourManager = ColourManager.managerFor(Display.getDefault());
     // return colourManager;
     // }
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/actions/CalculateStatisticsAction.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/actions/CalculateStatisticsAction.java
@@ -50,7 +50,7 @@ public class CalculateStatisticsAction extends AbstractPMDAction {
     @Override
     public void run() {
         try {
-            final ProgressMonitorDialog dialog = new ProgressMonitorDialog(Display.getCurrent().getActiveShell());
+            final ProgressMonitorDialog dialog = new ProgressMonitorDialog(Display.getDefault().getActiveShell());
             dialog.setCancelable(true);
 
             dialog.run(false, false, new IRunnableWithProgress() {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/actions/ReviewAction.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/actions/ReviewAction.java
@@ -81,7 +81,7 @@ public class ReviewAction extends AbstractViolationSelectionAction {
         // If only one marker selected or user has confirmed, review violation
         if (go) {
             try {
-                ProgressMonitorDialog dialog = new ProgressMonitorDialog(Display.getCurrent().getActiveShell());
+                ProgressMonitorDialog dialog = new ProgressMonitorDialog(Display.getDefault().getActiveShell());
                 dialog.run(false, false, new IRunnableWithProgress() {
                     @Override
                     public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {
@@ -104,7 +104,7 @@ public class ReviewAction extends AbstractViolationSelectionAction {
         if (markers.length > 1 && !reviewPmdStyle) {
             String title = getString(StringKeys.CONFIRM_TITLE);
             String message = getString(StringKeys.CONFIRM_REVIEW_MULTIPLE_MARKERS);
-            Shell shell = Display.getCurrent().getActiveShell();
+            Shell shell = Display.getDefault().getActiveShell();
             go = MessageDialog.openConfirm(shell, title, message);
         }
         return go;
@@ -139,7 +139,7 @@ public class ReviewAction extends AbstractViolationSelectionAction {
 
                     monitorWorked();
                 } else {
-                    MessageDialog.openError(Display.getCurrent().getActiveShell(), getString(StringKeys.ERROR_TITLE),
+                    MessageDialog.openError(Display.getDefault().getActiveShell(), getString(StringKeys.ERROR_TITLE),
                             "The file " + file.getName()
                                     + " doesn't exist, review aborted. Try to refresh the workspace and retry.");
                 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/actions/ReviewResourceAction.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/actions/ReviewResourceAction.java
@@ -49,7 +49,7 @@ public class ReviewResourceAction extends AbstractPMDAction {
     @Override
     public void run() {
         try {
-            ProgressMonitorDialog dialog = new ProgressMonitorDialog(Display.getCurrent().getActiveShell());
+            ProgressMonitorDialog dialog = new ProgressMonitorDialog(Display.getDefault().getActiveShell());
             dialog.run(false, false, new IRunnableWithProgress() {
                 @Override
                 public void run(IProgressMonitor monitor) throws InvocationTargetException, InterruptedException {

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/cpd2/CPDViewTooltipListener2.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/views/cpd2/CPDViewTooltipListener2.java
@@ -47,7 +47,7 @@ public class CPDViewTooltipListener2 implements Listener {
     }
 
     private void initialize() {
-        Display disp = Display.getCurrent();
+        Display disp = Display.getDefault();
         normalCursor = disp.getSystemCursor(SWT.CURSOR_ARROW);
         handCursor = disp.getSystemCursor(SWT.CURSOR_HAND);
     }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/util/AbstractCellPainterBuilder.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/util/AbstractCellPainterBuilder.java
@@ -54,7 +54,7 @@ public abstract class AbstractCellPainterBuilder implements CellPainterBuilder {
             return colourManager;
         }
 
-        colourManager = ColourManager.managerFor(Display.getCurrent());
+        colourManager = ColourManager.managerFor(Display.getDefault());
         return colourManager;
     }
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/util/StyledTextBuilder.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/util/StyledTextBuilder.java
@@ -25,7 +25,7 @@ import net.sourceforge.pmd.eclipse.ui.preferences.br.RuleFieldAccessor;
 
 public class StyledTextBuilder extends AbstractCellPainterBuilder {
 
-    private Display display = Display.getCurrent(); // NOPMD by br on 2/22/11 11:22 PM
+    private Display display = Display.getDefault(); // NOPMD by br on 2/22/11 11:22 PM
     private TextLayout layout = new TextLayout(display);
     private final TextStyle style;
 


### PR DESCRIPTION
Also make sure to use Display.getDefault() instead of
Display.getCurrent() - the latter might return null if not
in UI thread.

Avoid deadlock while creating PriorityDescriptorCache by
lazy populating the cache on demand instead of eagerly.

Fixes #148