### PR TITLE
Radio button for local rules in project properties dialog is missing

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -15,6 +15,7 @@ This is a minor release.
 
 ### Fixed Issues
 
+* [#171](https://github.com/pmd/pmd-eclipse-plugin/pull/171):   Radio button for local rules in project properties dialog is missing
 * [#178](https://github.com/pmd/pmd-eclipse-plugin/issues/178): Message not interpolated in "Show details..." dialog
 
 ### API Changes

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/AbstractSWTBotTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/AbstractSWTBotTest.java
@@ -1,0 +1,63 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+
+package net.sourceforge.pmd.eclipse;
+
+import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
+import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.WorkbenchException;
+import org.eclipse.ui.navigator.resources.ProjectExplorer;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+
+@RunWith(SWTBotJunit4ClassRunner.class)
+public abstract class AbstractSWTBotTest {
+    protected static SWTWorkbenchBot bot;
+
+    @BeforeClass
+    public static void initBot() throws InterruptedException {
+        bot = new SWTWorkbenchBot();
+        for (SWTBotView view : bot.views()) {
+            if ("Welcome".equals(view.getTitle())) {
+                view.close();
+            }
+        }
+        openJavaPerspective();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        try {
+            bot.resetWorkbench();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    protected static void openJavaPerspective() throws InterruptedException {
+        Display.getDefault().syncExec(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    IWorkbench workbench = PlatformUI.getWorkbench();
+                    IWorkbenchWindow activeWorkbenchWindow = workbench.getActiveWorkbenchWindow();
+                    workbench.showPerspective(JavaUI.ID_PERSPECTIVE, activeWorkbenchWindow);
+                    IWorkbenchPage activePage = activeWorkbenchWindow.getActivePage();
+                    activePage.showView(ProjectExplorer.VIEW_ID);
+                } catch (WorkbenchException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
+}

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/internal/ResourceUtil.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/internal/ResourceUtil.java
@@ -7,8 +7,14 @@ package net.sourceforge.pmd.eclipse.internal;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.io.Reader;
 import java.nio.file.Files;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.runtime.CoreException;
 
 public final class ResourceUtil {
     private ResourceUtil() {
@@ -30,5 +36,23 @@ public final class ResourceUtil {
                 count = in.read(buffer);
             }
         }
+    }
+
+    public static String getResourceAsString(IProject project, String resourceName) throws IOException, CoreException {
+        IFile file = project.getFile(resourceName);
+        String charset = file.getCharset();
+        char[] buffer = new char[1024];
+        StringBuilder result = new StringBuilder();
+        try (Reader in = new InputStreamReader(file.getContents(), charset)) {
+            int count = in.read(buffer);
+            while (count > -1) {
+                result.append(buffer, 0, count);
+                count = in.read(buffer);
+            }
+            if (count > -1) {
+                result.append(buffer, 0, count);
+            }
+        }
+        return result.toString();
     }
 }

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/dialogs/ViolationDetailsDialogTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/dialogs/ViolationDetailsDialogTest.java
@@ -14,61 +14,32 @@ import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IncrementalProjectBuilder;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
-import org.eclipse.jdt.ui.JavaUI;
 import org.eclipse.swt.widgets.Display;
-import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
-import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
 import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTableItem;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTree;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
 import org.eclipse.ui.IWorkbench;
-import org.eclipse.ui.IWorkbenchPage;
 import org.eclipse.ui.IWorkbenchWindow;
 import org.eclipse.ui.PlatformUI;
 import org.eclipse.ui.WorkbenchException;
-import org.eclipse.ui.navigator.resources.ProjectExplorer;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
+import net.sourceforge.pmd.eclipse.AbstractSWTBotTest;
 import net.sourceforge.pmd.eclipse.EclipseUtils;
 import net.sourceforge.pmd.eclipse.plugin.PMDPlugin;
 import net.sourceforge.pmd.eclipse.runtime.PMDRuntimeConstants;
 import net.sourceforge.pmd.eclipse.runtime.properties.IProjectProperties;
 
-@RunWith(SWTBotJunit4ClassRunner.class)
-public class ViolationDetailsDialogTest {
-    private static SWTWorkbenchBot bot;
+public class ViolationDetailsDialogTest extends AbstractSWTBotTest {
     private static final String PROJECT_NAME = ViolationDetailsDialogTest.class.getSimpleName();
 
     private IProject testProject;
-
-    @BeforeClass
-    public static void initBot() throws InterruptedException {
-        bot = new SWTWorkbenchBot();
-        for (SWTBotView view : bot.views()) {
-            if ("Welcome".equals(view.getTitle())) {
-                view.close();
-            }
-        }
-    }
-
-    @AfterClass
-    public static void afterClass() {
-        try {
-            bot.resetWorkbench();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
-
 
     @Before
     public void setUp() throws Exception {
@@ -173,23 +144,6 @@ public class ViolationDetailsDialogTest {
                     IWorkbench workbench = PlatformUI.getWorkbench();
                     IWorkbenchWindow activeWorkbenchWindow = workbench.getActiveWorkbenchWindow();
                     workbench.showPerspective(PMDRuntimeConstants.ID_PERSPECTIVE, activeWorkbenchWindow);
-                } catch (WorkbenchException e) {
-                    e.printStackTrace();
-                }
-            }
-        });
-    }
-
-    private static void openJavaPerspective() throws InterruptedException {
-        Display.getDefault().syncExec(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    IWorkbench workbench = PlatformUI.getWorkbench();
-                    IWorkbenchWindow activeWorkbenchWindow = workbench.getActiveWorkbenchWindow();
-                    workbench.showPerspective(JavaUI.ID_PERSPECTIVE, activeWorkbenchWindow);
-                    IWorkbenchPage activePage = activeWorkbenchWindow.getActivePage();
-                    activePage.showView(ProjectExplorer.VIEW_ID);
                 } catch (WorkbenchException e) {
                     e.printStackTrace();
                 }

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/dialogs/ViolationDetailsDialogTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/dialogs/ViolationDetailsDialogTest.java
@@ -16,6 +16,7 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
+import org.eclipse.swtbot.swt.finder.exceptions.WidgetNotFoundException;
 import org.eclipse.swtbot.swt.finder.waits.DefaultCondition;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTableItem;
@@ -83,9 +84,27 @@ public class ViolationDetailsDialogTest extends AbstractSWTBotTest {
         openJavaPerspective();
 
         SWTBotView problemsView = bot.viewByPartName("Problems");
-        problemsView.bot().tree().getTreeItem("Warnings (4 items)").expand();
-        SWTBotTreeItem item = problemsView.bot().tree().getTreeItem("Warnings (4 items)").getNode("UnnecessaryModifier: Unnecessary modifier 'public' on method 'run': the method is declared in an interface type").select();
-        item.contextMenu("Show details...").click();
+        SWTBotTreeItem item = problemsView.bot().tree().getTreeItem("Warnings (4 items)").expand();
+        String markerText = "UnnecessaryModifier: Unnecessary modifier 'public' on method 'run': the method is declared in an interface type";
+
+        bot.waitUntil(new DefaultCondition() {
+            @Override
+            public boolean test() throws Exception {
+                try {
+                    item.getNode(markerText);
+                } catch (WidgetNotFoundException e) {
+                    return false;
+                }
+                return true;
+            }
+
+            @Override
+            public String getFailureMessage() {
+                return "Marker not found";
+            }
+        });
+        SWTBotTreeItem markerItem = item.getNode(markerText).select();
+        markerItem.contextMenu("Show details...").click();
 
         assertDialog();
     }

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/dialogs/ViolationDetailsDialogTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/dialogs/ViolationDetailsDialogTest.java
@@ -84,13 +84,13 @@ public class ViolationDetailsDialogTest extends AbstractSWTBotTest {
         openJavaPerspective();
 
         SWTBotView problemsView = bot.viewByPartName("Problems");
-        SWTBotTreeItem item = problemsView.bot().tree().getTreeItem("Warnings (4 items)").expand();
         String markerText = "UnnecessaryModifier: Unnecessary modifier 'public' on method 'run': the method is declared in an interface type";
 
-        bot.waitUntil(new DefaultCondition() {
+        problemsView.bot().waitUntil(new DefaultCondition() {
             @Override
             public boolean test() throws Exception {
                 try {
+                    SWTBotTreeItem item = bot.tree().getTreeItem("Warnings (4 items)").expand();
                     item.getNode(markerText);
                 } catch (WidgetNotFoundException e) {
                     return false;
@@ -103,6 +103,7 @@ public class ViolationDetailsDialogTest extends AbstractSWTBotTest {
                 return "Marker not found";
             }
         });
+        SWTBotTreeItem item = problemsView.bot().tree().getTreeItem("Warnings (4 items)").expand();
         SWTBotTreeItem markerItem = item.getNode(markerText).select();
         markerItem.contextMenu("Show details...").click();
 

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/PMDProjectPropertyPageTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/PMDProjectPropertyPageTest.java
@@ -1,0 +1,155 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+
+package net.sourceforge.pmd.eclipse.ui.properties;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.core.resources.IProject;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.jdt.ui.JavaUI;
+import org.eclipse.swt.widgets.Display;
+import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
+import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
+import org.eclipse.swtbot.swt.finder.SWTBot;
+import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotCheckBox;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
+import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.IWorkbenchWindow;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.WorkbenchException;
+import org.eclipse.ui.navigator.resources.ProjectExplorer;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import net.sourceforge.pmd.eclipse.EclipseUtils;
+import net.sourceforge.pmd.eclipse.internal.ResourceUtil;
+
+@RunWith(SWTBotJunit4ClassRunner.class)
+public class PMDProjectPropertyPageTest {
+    private static SWTWorkbenchBot bot;
+    private static final String PROJECT_NAME = PMDProjectPropertyPageTest.class.getName();
+
+    private IProject testProject;
+
+    @BeforeClass
+    public static void initBot() throws InterruptedException {
+        bot = new SWTWorkbenchBot();
+        for (SWTBotView view : bot.views()) {
+            if ("Welcome".equals(view.getTitle())) {
+                view.close();
+            }
+        }
+        openJavaPerspective();
+    }
+
+    @AfterClass
+    public static void afterClass() {
+        try {
+            bot.resetWorkbench();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        this.testProject = EclipseUtils.createJavaProject(PROJECT_NAME);
+        assertTrue("A test project cannot be created; the tests cannot be performed.",
+                this.testProject != null && this.testProject.exists() && this.testProject.isAccessible());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        if (this.testProject != null) {
+            if (this.testProject.exists() && this.testProject.isAccessible()) {
+                EclipseUtils.removePMDNature(this.testProject);
+                this.testProject.refreshLocal(IResource.DEPTH_INFINITE, null);
+                this.testProject.delete(true, true, null);
+                this.testProject = null;
+            } else {
+                System.out.println("WARNING: Test Project has not been deleted!");
+            }
+        }
+    }
+
+    @Test
+    public void twoRadioButtonsForRuleSelectionAreShown() {
+        SWTBot dialogBot = openProjectProperties();
+        SWTBotCheckBox enablePmdCheckbox = dialogBot.checkBox("Enable PMD");
+        assertFalse("PMD should not enabled by default", enablePmdCheckbox.isChecked());
+        enablePmdCheckbox.click();
+        assertNotNull(dialogBot.radio("Use local rules"));
+        assertTrue("local rules should be used by default", dialogBot.radio("Use local rules").isSelected());
+        assertNotNull(dialogBot.radio("Use the ruleset configured in a project file"));
+        dialogBot.button("Cancel").click();
+    }
+
+    /**
+     * When switching between local rules and ruleset file, only one option of the two
+     * should be persisted in the ".pmd" file.
+     */
+    @Test
+    public void verifyProjectPropertiesAfterSwitchingFromRulesetFileToLocal() throws Exception {
+        // first enable PMD with local rules (default)
+        SWTBot dialogBot = openProjectProperties();
+        dialogBot.checkBox("Enable PMD").click();
+        dialogBot.button("Apply and Close").click();
+
+        String projectProperties = ResourceUtil.getResourceAsString(testProject, ".pmd");
+        assertFalse("No ruleSetFile should be in the properties", projectProperties.contains("<ruleSetFile>"));
+        assertTrue("rules should be in the properties", projectProperties.contains("<rules>"));
+        assertTrue(projectProperties.contains("<useProjectRuleSet>false</useProjectRuleSet>"));
+
+        // now enable ruleset file
+        dialogBot = openProjectProperties();
+        dialogBot.radio("Use the ruleset configured in a project file").click();
+        dialogBot.button("Apply and Close").click();
+        
+        bot.shell("PMD Question").bot().button("Yes").click();
+        
+        projectProperties = ResourceUtil.getResourceAsString(testProject, ".pmd");
+        assertTrue("ruleSetFile should be in the properties", projectProperties.contains("<ruleSetFile>"));
+        assertFalse("No rules should be in the properties", projectProperties.contains("<rules>"));
+        assertTrue(projectProperties.contains("<useProjectRuleSet>true</useProjectRuleSet>"));
+    }
+
+    private SWTBot openProjectProperties() {
+        SWTBotView projectExplorer = bot.viewByTitle("Project Explorer");
+        projectExplorer.show();
+        SWTBotTreeItem projectItem = projectExplorer.bot().tree().getTreeItem(PROJECT_NAME);
+        projectItem.select();
+        projectItem.contextMenu().menu("Properties", false, 0).click();
+        SWTBotShell dialog = bot.shell("Properties for " + PROJECT_NAME);
+        dialog.bot().tree().getTreeItem("PMD").select();
+        return dialog.bot();
+    }
+
+    private static void openJavaPerspective() throws InterruptedException {
+        Display.getDefault().syncExec(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    IWorkbench workbench = PlatformUI.getWorkbench();
+                    IWorkbenchWindow activeWorkbenchWindow = workbench.getActiveWorkbenchWindow();
+                    workbench.showPerspective(JavaUI.ID_PERSPECTIVE, activeWorkbenchWindow);
+                    IWorkbenchPage activePage = activeWorkbenchWindow.getActivePage();
+                    activePage.showView(ProjectExplorer.VIEW_ID);
+                } catch (WorkbenchException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
+}

--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/PMDProjectPropertyPageTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/PMDProjectPropertyPageTest.java
@@ -11,57 +11,23 @@ import static org.junit.Assert.assertTrue;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
-import org.eclipse.jdt.ui.JavaUI;
-import org.eclipse.swt.widgets.Display;
-import org.eclipse.swtbot.eclipse.finder.SWTWorkbenchBot;
 import org.eclipse.swtbot.eclipse.finder.widgets.SWTBotView;
 import org.eclipse.swtbot.swt.finder.SWTBot;
-import org.eclipse.swtbot.swt.finder.junit.SWTBotJunit4ClassRunner;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotCheckBox;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotShell;
 import org.eclipse.swtbot.swt.finder.widgets.SWTBotTreeItem;
-import org.eclipse.ui.IWorkbench;
-import org.eclipse.ui.IWorkbenchPage;
-import org.eclipse.ui.IWorkbenchWindow;
-import org.eclipse.ui.PlatformUI;
-import org.eclipse.ui.WorkbenchException;
-import org.eclipse.ui.navigator.resources.ProjectExplorer;
 import org.junit.After;
-import org.junit.AfterClass;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
+import net.sourceforge.pmd.eclipse.AbstractSWTBotTest;
 import net.sourceforge.pmd.eclipse.EclipseUtils;
 import net.sourceforge.pmd.eclipse.internal.ResourceUtil;
 
-@RunWith(SWTBotJunit4ClassRunner.class)
-public class PMDProjectPropertyPageTest {
-    private static SWTWorkbenchBot bot;
-    private static final String PROJECT_NAME = PMDProjectPropertyPageTest.class.getName();
+public class PMDProjectPropertyPageTest extends AbstractSWTBotTest {
+    private static final String PROJECT_NAME = PMDProjectPropertyPageTest.class.getSimpleName();
 
     private IProject testProject;
-
-    @BeforeClass
-    public static void initBot() throws InterruptedException {
-        bot = new SWTWorkbenchBot();
-        for (SWTBotView view : bot.views()) {
-            if ("Welcome".equals(view.getTitle())) {
-                view.close();
-            }
-        }
-        openJavaPerspective();
-    }
-
-    @AfterClass
-    public static void afterClass() {
-        try {
-            bot.resetWorkbench();
-        } catch (Exception e) {
-            e.printStackTrace();
-        }
-    }
 
     @Before
     public void setUp() throws Exception {
@@ -134,22 +100,5 @@ public class PMDProjectPropertyPageTest {
         SWTBotShell dialog = bot.shell("Properties for " + PROJECT_NAME);
         dialog.bot().tree().getTreeItem("PMD").select();
         return dialog.bot();
-    }
-
-    private static void openJavaPerspective() throws InterruptedException {
-        Display.getDefault().syncExec(new Runnable() {
-            @Override
-            public void run() {
-                try {
-                    IWorkbench workbench = PlatformUI.getWorkbench();
-                    IWorkbenchWindow activeWorkbenchWindow = workbench.getActiveWorkbenchWindow();
-                    workbench.showPerspective(JavaUI.ID_PERSPECTIVE, activeWorkbenchWindow);
-                    IWorkbenchPage activePage = activeWorkbenchWindow.getActivePage();
-                    activePage.showView(ProjectExplorer.VIEW_ID);
-                } catch (WorkbenchException e) {
-                    e.printStackTrace();
-                }
-            }
-        });
     }
 }

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesManagerImpl.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/impl/ProjectPropertiesManagerImpl.java
@@ -331,15 +331,16 @@ public class ProjectPropertiesManagerImpl implements IProjectPropertiesManager {
      */
     private ProjectPropertiesTO fillTransferObject(IProjectProperties projectProperties) throws PropertiesException {
         final ProjectPropertiesTO bean = new ProjectPropertiesTO();
-        bean.setRuleSetStoredInProject(projectProperties.isRuleSetStoredInProject());
-        bean.setRuleSetFile(projectProperties.getRuleSetFile());
         bean.setWorkingSetName(projectProperties.getProjectWorkingSet() == null ? null
                 : projectProperties.getProjectWorkingSet().getName());
         bean.setIncludeDerivedFiles(projectProperties.isIncludeDerivedFiles());
         bean.setViolationsAsErrors(projectProperties.violationsAsErrors());
         bean.setFullBuildEnabled(projectProperties.isFullBuildEnabled());
 
-        if (!projectProperties.isRuleSetStoredInProject()) {
+        bean.setRuleSetStoredInProject(projectProperties.isRuleSetStoredInProject());
+        if (projectProperties.isRuleSetStoredInProject()) {
+            bean.setRuleSetFile(projectProperties.getRuleSetFile());
+        } else {
             final List<RuleSet> ruleSets = projectProperties.getProjectRuleSetList();
             final List<RuleSpecTO> rules = new ArrayList<>();
             List<String> excludePatterns = new ArrayList<>();

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/PMDProjectPropertyPage.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/ui/properties/PMDProjectPropertyPage.java
@@ -176,6 +176,7 @@ public class PMDProjectPropertyPage extends PropertyPage {
             ruleSetStoredInProjectButton = buildStoreRuleSetInProjectButton(ruleSetPanel);
             ruleSetFileText = buildRuleSetFileText(ruleSetPanel);
             ruleSetBrowseButton = buildRuleSetBrowseButton(ruleSetPanel);
+            buildLocalRulesButton(ruleSetPanel);
 
             data = new GridData(SWT.FILL, SWT.NONE, true, false);
             ruleSetFileText.setLayoutData(data);
@@ -327,25 +328,26 @@ public class PMDProjectPropertyPage extends PropertyPage {
         return button;
     }
 
-    //    /**
-    //     * Create the radio button for storing configuration in a project file
-    //     * 
-    //     * @param parent
-    //     *            the parent composite
-    //     */
-    //    private Button buildLocalRulesButton(final Composite parent) {
-    //        Button button = newRadioButton(parent, "Use local rules");
-    //
-    //        button.setSelection(!model.isRuleSetStoredInProject());
-    //
-    //        button.addSelectionListener(new SelectionAdapter() {
-    //            public void widgetSelected(SelectionEvent e) {
-    //                adjustControls();
-    //            }
-    //        });
-    //
-    //        return button;
-    //    }
+    /**
+     * Create the radio button for storing configuration in a project file
+     * 
+     * @param parent
+     *            the parent composite
+     */
+    private Button buildLocalRulesButton(final Composite parent) {
+        Button button = newRadioButton(parent, "Use local rules");
+
+        button.setSelection(!model.isRuleSetStoredInProject());
+
+        button.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                adjustControls();
+            }
+        });
+
+        return button;
+    }
 
     /**
      * Create the the rule set file name text.


### PR DESCRIPTION
When opening the project properties, you can select a external ruleset file. But you can't go back to the previous setting, because there is not radio button:

![image](https://github.com/pmd/pmd-eclipse-plugin/assets/1573684/f0e21591-2391-4286-8c7d-38a19be2cf87)

This PR fixes that, so that we have a second radio button again:

![image](https://github.com/pmd/pmd-eclipse-plugin/assets/1573684/a620a51b-3fdc-4e6f-ae1a-2da27abe8727)
