### PR TITLE
Support macos on arm64/aarch64

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -477,6 +477,11 @@
                   <ws>cocoa</ws>
                   <arch>x86_64</arch>
                 </environment>
+                <environment>
+                  <os>macosx</os>
+                  <ws>cocoa</ws>
+                  <arch>aarch64</arch>
+                </environment>
               </environments>
             </configuration>
           </plugin>


### PR DESCRIPTION
Github runners are now using macos 14 on arm64...

See also https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/

