### PR TITLE
Explicitly refresh and rebuild test project after .classpath change

### DIFF
--- a/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/ProjectPropertiesModelTest.java
+++ b/net.sourceforge.pmd.eclipse.plugin.test/src/main/java/net/sourceforge/pmd/eclipse/runtime/properties/ProjectPropertiesModelTest.java
@@ -573,6 +573,11 @@ public class ProjectPropertiesModelTest {
             + "    <classpathentry kind=\"lib\" path=\"/ExternalProject/sample-lib4.jar\"/>\n"
             + "</classpath>\n";
         file.setContents(IOUtils.toInputStream(newClasspathContent, "UTF-8"), 0, null);
+        // refresh, so that changed .classpath file is considered
+        this.testProject.refreshLocal(IResource.DEPTH_INFINITE, null);
+        // rebuild again, so that changed classpath is configured on java project
+        this.testProject.build(IncrementalProjectBuilder.FULL_BUILD, null);
+
         final IProjectPropertiesManager mgr = PMDPlugin.getDefault().getPropertiesManager();
         IProjectProperties model = mgr.loadProjectProperties(this.testProject);
         URLClassLoader auxClasspath = (URLClassLoader) model.getAuxClasspath(); // NOPMD: don't close auxclasspath in test, this should be done by the plugin


### PR DESCRIPTION
This hopefully fixes spurious test failures, like this one:

ProjectPropertiesModelTest.testProjectClasspath:584 Found these URIs: [file:/usr/lib/jvm/temurin-21-jdk-amd64/lib/jrt-fs.jar, file:/home/runner/work/pmd-eclipse-plugin/pmd-eclipse-plugin/net.sourceforge.pmd.eclipse.plugin.test/target/work/data/ProjectPropertiesModelTest/bin/] expected: 6 but was: 2

E.g. happened in https://github.com/pmd/pmd-eclipse-plugin/actions/runs/13601379628
and in https://github.com/pmd/pmd-eclipse-plugin/actions/runs/13753871134/job/38458276451?pr=262