### PR TITLE
chore: Improve do-release.sh

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -17,6 +17,7 @@ This is a minor release.
 
 ### ✨ Merged pull requests
 * [#290](https://github.com/pmd/pmd-eclipse-plugin/pull/290): chore: Add pmd-css - [Andreas Dangel](https://github.com/adangel) (@adangel)
+* [#291](https://github.com/pmd/pmd-eclipse-plugin/pull/291): chore: Improve do-release.sh - [Andreas Dangel](https://github.com/adangel) (@adangel)
 
 ### 📦 Dependency updates
 

--- a/do-release.sh
+++ b/do-release.sh
@@ -68,6 +68,14 @@ echo
 echo "Press enter to continue... (or CTRL+C to cancel)"
 read -r
 
+echo
+echo "Has the PMD version been upgraded? Did this version introduce a new language?"
+echo "If yes, then update net.sourceforge.pmd.eclipse.plugin/META-INF/MANIFEST.MF and"
+echo "net.sourceforge.pmd.eclipse.plugin/build.properties to add the new pmd module jar."
+echo
+echo "Press enter to continue... (or CTRL+C to cancel)"
+read -r
+
 echo Update the ReleaseNotes with the release date and version:
 echo 
 echo "## $(date -u +%d-%B-%Y): ${RELEASE_VERSION}.${BUILDQUALIFIER}"
@@ -121,7 +129,7 @@ echo
 echo Checkout the release branch and build the plugin
 git checkout "pmd-eclipse-plugin-rb-${RELEASE_VERSION}"
 
-./mvnw clean verify
+./mvnw clean verify -U
 
 # extract the release notes
 BEGIN_LINE=$(grep -n "^## " ReleaseNotes.md|head -1|cut -d ":" -f 1)


### PR DESCRIPTION
- Add a safety question whether a new pmd language module would need to be included
- Build the plugin with "-U" locally, so that fetching a new PMD version won't fail. Locally, maven could have tried to fetch it before it was available in central and remembered that the new PMD version is not there.