### PR TITLE
refactor: Remove custom JavaProject cache

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -17,6 +17,7 @@ This is a minor release.
 
 ### ✨ Merged pull requests
 * [#431](https://github.com/pmd/pmd-eclipse-plugin/pull/431): chore: Improve logging during tests at waitForPMDJobs - [Andreas Dangel](https://github.com/adangel) (@adangel)
+* [#432](https://github.com/pmd/pmd-eclipse-plugin/pull/432): refactor: Remove custom JavaProject cache - [Andreas Dangel](https://github.com/adangel) (@adangel)
 
 ### 📦 Dependency updates
 

--- a/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/PMDPlugin.java
+++ b/net.sourceforge.pmd.eclipse.plugin/src/main/java/net/sourceforge/pmd/eclipse/plugin/PMDPlugin.java
@@ -83,8 +83,6 @@ import net.sourceforge.pmd.lang.rule.RuleSetLoader;
 public class PMDPlugin extends AbstractUIPlugin {
     private static final Logger LOG = LoggerFactory.getLogger(PMDPlugin.class);
 
-    private static Map<IProject, IJavaProject> javaProjectsByIProject = new HashMap<>();
-
     // The shared instance
     private static PMDPlugin plugin;
 
@@ -126,44 +124,47 @@ public class PMDPlugin extends AbstractUIPlugin {
 
     /**
      * Return the Java language version for the resources found within the specified project or null if it isn't a Java
-     * project or a Java version we don't support yet.
+     * project or a Java version we don't support yet or the project doesn't exist.
      * 
      * @param project
      * @return
      */
     public static LanguageVersion javaVersionFor(IProject project) {
-
-        IJavaProject jProject = javaProjectsByIProject.get(project);
-        if (jProject == null) {
-            jProject = JavaCore.create(project);
-            javaProjectsByIProject.put(project, jProject);
+        if (!project.exists()) {
+            return null;
         }
 
-        if (jProject.exists()) {
-            String compilerCompliance = jProject.getOption(JavaCore.COMPILER_COMPLIANCE, true);
-            return JavaLanguageModule.getInstance().getVersion(compilerCompliance);
+        IJavaProject jProject = JavaCore.create(project);
+        if (!jProject.exists()) {
+            return null;
         }
-        return null;
+
+        String compilerCompliance = jProject.getOption(JavaCore.COMPILER_COMPLIANCE, true);
+        return JavaLanguageModule.getInstance().getVersion(compilerCompliance);
     }
 
     public static IClasspathEntry buildSourceClassPathEntryFor(IProject project) {
-        IJavaProject jProject = javaProjectsByIProject.get(project);
-        if (jProject == null) {
-            jProject = JavaCore.create(project);
-            javaProjectsByIProject.put(project, jProject);
+        if (!project.exists()) {
+            return null;
         }
-        if (jProject.exists()) {
-            try {
-                if (jProject.getRawClasspath() != null) {
-                    for (IClasspathEntry entry : jProject.getRawClasspath()) {
-                        if (entry.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
-                            return entry;
-                        }
+
+        IJavaProject jProject = JavaCore.create(project);
+        if (!jProject.exists()) {
+            return null;
+        }
+
+        try {
+            IClasspathEntry[] rawClasspath = jProject.getRawClasspath();
+            if (rawClasspath != null) {
+                for (IClasspathEntry entry : rawClasspath) {
+                    if (entry.getEntryKind() == IClasspathEntry.CPE_SOURCE) {
+                        LOG.debug("Found source classpath entry: path={}", entry.getPath());
+                        return entry;
                     }
                 }
-            } catch (JavaModelException e) {
-                LOG.error("Couldn't determine source classpath", e);
             }
+        } catch (JavaModelException e) {
+            LOG.error("Couldn't determine source classpath", e);
         }
         return null;
     }


### PR DESCRIPTION

I've seen some test failure with the error message:

```
net.sourceforge.pmd.eclipse.ui.dialogs.ViolationDetailsDialogTest.openDialogViaProblemView -- Time elapsed: 0.094 s <<< ERROR!
java.lang.IllegalArgumentException: Path must include project and resource name: /ViolationDetailsDialogTest
	at org.eclipse.core.runtime.Assert.isLegal(Assert.java:68)
	at org.eclipse.core.internal.resources.Workspace.newResource(Workspace.java:2274)
	at org.eclipse.core.internal.resources.Container.getFolder(Container.java:216)
	at net.sourceforge.pmd.eclipse.runtime.properties.impl.ProjectPropertiesImpl.determineBuildPathIncludesExcludes(ProjectPropertiesImpl.java:93)
	at net.sourceforge.pmd.eclipse.runtime.properties.impl.ProjectPropertiesImpl.<init>(ProjectPropertiesImpl.java:83)
	at net.sourceforge.pmd.eclipse.runtime.properties.impl.PropertiesFactoryImpl.newProjectProperties(PropertiesFactoryImpl.java:32)
	at net.sourceforge.pmd.eclipse.runtime.properties.impl.ProjectPropertiesManagerImpl.loadProjectProperties(ProjectPropertiesManagerImpl.java:87)
	at net.sourceforge.pmd.eclipse.ui.dialogs.ViolationDetailsDialogTest.setUp(ViolationDetailsDialogTest.java:59)
```

I don't think, caching these instances is the correct way. If JavaCore.create() is slow, then the caching should happen in eclipse framework, and not in the PMD plugin itself.

The difference is: The cache might contain a project, whose dependent projects are closed, which could result in wrong analysis. JavaCore.create() opens all dependent projects as a side-effect.

The test failure happens only sporadically. So - if with this change all other tests work find, I'll just merge this PR.
