### PR TITLE
fix(gh-actions): provide gpg passphrase configuration

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -101,6 +101,7 @@ jobs:
           distribution: temurin
           java-version: '21'
           gpg-private-key: ${{ secrets.PMD_CI_GPG_PRIVATE_KEY }}
+          gpg-passphrase-env-var: MAVEN_GPG_PASSPHRASE
 
       - name: Cache local Maven repository
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -91,6 +91,7 @@ jobs:
           distribution: temurin
           java-version: '21'
           gpg-private-key: ${{ secrets.PMD_CI_GPG_PRIVATE_KEY }}
+          gpg-passphrase-env-var: MAVEN_GPG_PASSPHRASE
 
       - name: Cache local Maven repository
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 #v6.1.0


### PR DESCRIPTION
We use the m-gpg-p's default environment variable MAVEN_GPG_PASSPHRASE but setup-java configures it to use GPG_PASSPHRASE by default, if not set explicitly.